### PR TITLE
fix: kubeconfig properties

### DIFF
--- a/projects/wc/src/app/components/generic-ui/detail-view/kubeconfig-template.ts
+++ b/projects/wc/src/app/components/generic-ui/detail-view/kubeconfig-template.ts
@@ -21,9 +21,8 @@ export const kubeConfigTemplate = `
           - oidc-login
           - get-token
           - --oidc-issuer-url=<oidc-issuer-url>
-          - --oidc-client-id=<org-name>
+          - --oidc-client-id=kubectl
           - --oidc-extra-scope=email
-          - --oidc-extra-scope=groups
           command: kubectl
           env: null
           interactiveMode: IfAvailable


### PR DESCRIPTION
During testing on cc-d2 and cc-two we found some issues when trying to work with the downloaded kubeconfig