### PR TITLE
chore: add publishConfig to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   },
   "author": "Platform Mesh",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "ng": "ng",
     "build": "npm run build:lib && npm run build:wc",


### PR DESCRIPTION
## Summary
- Add `publishConfig` field with `"access": "public"` to package.json

## Purpose
This change enables the organization-wide Renovate configuration to properly detect this repository as a publishable library rather than an application.

## Impact
With this change, Renovate will:
- Convert exact dependency versions to ranges (e.g., `1.2.3` → `^1.2.3`) when updating
- Allow library consumers to automatically receive compatible updates
- Apply the appropriate `replace` range strategy for library dependencies

## Related Changes
This is part of a coordinated update to improve dependency management across the platform-mesh organization:
- Similar PR will be created for `portal-server-lib`
- Organization Renovate config updated to use `publishConfig` for library detection