### PR TITLE
feat: add ui.title and ui.description overrides to list view

### DIFF
--- a/projects/lib/models/models/ui-definition.ts
+++ b/projects/lib/models/models/ui-definition.ts
@@ -106,6 +106,8 @@ export interface UiView {
 
 export interface UIDefinition {
   logoUrl?: string;
+  title?: string;
+  description?: string;
   listView?: UiView;
   createView?: UiView;
   detailView?: DetailView;

--- a/projects/lib/models/models/ui-definition.ts
+++ b/projects/lib/models/models/ui-definition.ts
@@ -106,8 +106,6 @@ export interface UiView {
 
 export interface UIDefinition {
   logoUrl?: string;
-  title?: string;
-  description?: string;
   listView?: UiView;
   createView?: UiView;
   detailView?: DetailView;

--- a/projects/wc/src/app/components/generic-ui/list-view/list-view.component.spec.ts
+++ b/projects/wc/src/app/components/generic-ui/list-view/list-view.component.spec.ts
@@ -1130,7 +1130,7 @@ describe('ListViewComponent', () => {
         expect(component.defaultTitle()).toBe('clusters');
       });
 
-      it('should use ui.title as defaultTitle when set', () => {
+      it('should use listView.resourceTitle.label as defaultTitle when set', () => {
         const newFixture = TestBed.createComponent(ListView);
         const newComponent = newFixture.componentInstance;
         newComponent.context = (() => ({
@@ -1140,8 +1140,7 @@ describe('ListViewComponent', () => {
             apiGroup: 'core_k8s_io',
             version: 'v1alpha1',
             ui: {
-              title: 'My Clusters',
-              listView: { fields: [] },
+              listView: { fields: [], resourceTitle: { label: 'My Clusters' } },
             },
           },
         })) as any;
@@ -1159,7 +1158,7 @@ describe('ListViewComponent', () => {
         );
       });
 
-      it('should use ui.description as defaultDescription when set', () => {
+      it('should use listView.resourceDescription.label as defaultDescription when set', () => {
         const newFixture = TestBed.createComponent(ListView);
         const newComponent = newFixture.componentInstance;
         newComponent.context = (() => ({
@@ -1169,8 +1168,7 @@ describe('ListViewComponent', () => {
             apiGroup: 'core_k8s_io',
             version: 'v1alpha1',
             ui: {
-              description: 'Custom description for clusters',
-              listView: { fields: [] },
+              listView: { fields: [], resourceDescription: { label: 'Custom description for clusters' } },
             },
           },
         })) as any;

--- a/projects/wc/src/app/components/generic-ui/list-view/list-view.component.spec.ts
+++ b/projects/wc/src/app/components/generic-ui/list-view/list-view.component.spec.ts
@@ -1126,6 +1126,64 @@ describe('ListViewComponent', () => {
     });
 
     describe('Computed properties', () => {
+      it('should use entityCollection as defaultTitle when ui.title is not set', () => {
+        expect(component.defaultTitle()).toBe('clusters');
+      });
+
+      it('should use ui.title as defaultTitle when set', () => {
+        const newFixture = TestBed.createComponent(ListView);
+        const newComponent = newFixture.componentInstance;
+        newComponent.context = (() => ({
+          resourceDefinition: {
+            entityCollection: 'clusters',
+            entity: 'Cluster',
+            apiGroup: 'core_k8s_io',
+            version: 'v1alpha1',
+            ui: {
+              title: 'My Clusters',
+              listView: { fields: [] },
+            },
+          },
+        })) as any;
+        newComponent.LuigiClient = (() => ({
+          linkManager: () => ({ fromContext: vi.fn().mockReturnThis(), navigate: vi.fn(), withParams: vi.fn().mockReturnThis() }),
+          getNodeParams: vi.fn(),
+        })) as any;
+        newFixture.detectChanges();
+        expect(newComponent.defaultTitle()).toBe('My Clusters');
+      });
+
+      it('should use default description when ui.description is not set', () => {
+        expect(component.defaultDescription()).toBe(
+          'This page displays the created clusters in your environment',
+        );
+      });
+
+      it('should use ui.description as defaultDescription when set', () => {
+        const newFixture = TestBed.createComponent(ListView);
+        const newComponent = newFixture.componentInstance;
+        newComponent.context = (() => ({
+          resourceDefinition: {
+            entityCollection: 'clusters',
+            entity: 'Cluster',
+            apiGroup: 'core_k8s_io',
+            version: 'v1alpha1',
+            ui: {
+              description: 'Custom description for clusters',
+              listView: { fields: [] },
+            },
+          },
+        })) as any;
+        newComponent.LuigiClient = (() => ({
+          linkManager: () => ({ fromContext: vi.fn().mockReturnThis(), navigate: vi.fn(), withParams: vi.fn().mockReturnThis() }),
+          getNodeParams: vi.fn(),
+        })) as any;
+        newFixture.detectChanges();
+        expect(newComponent.defaultDescription()).toBe(
+          'Custom description for clusters',
+        );
+      });
+
       it('should return false for hasUiCreateViewFields when createView is undefined', () => {
         const newFixture = TestBed.createComponent(ListView);
         const newComponent = newFixture.componentInstance;

--- a/projects/wc/src/app/components/generic-ui/list-view/list-view.component.ts
+++ b/projects/wc/src/app/components/generic-ui/list-view/list-view.component.ts
@@ -59,10 +59,13 @@ export class ListView {
   resources = signal<Resource[]>([]);
   defaultTitle = computed(
     () =>
-      this.resourceDefinition()?.entityCollection ?? '',
+      this.resourceDefinition()?.ui?.title ??
+      this.resourceDefinition()?.entityCollection ??
+      '',
   );
   defaultDescription = computed(
     () =>
+      this.resourceDefinition()?.ui?.description ??
       `This page displays the created ${this.resourceDefinition()?.entityCollection} in your environment`,
   );
   resourceDefinition = computed(() => this.context().resourceDefinition);

--- a/projects/wc/src/app/components/generic-ui/list-view/list-view.component.ts
+++ b/projects/wc/src/app/components/generic-ui/list-view/list-view.component.ts
@@ -59,13 +59,13 @@ export class ListView {
   resources = signal<Resource[]>([]);
   defaultTitle = computed(
     () =>
-      this.resourceDefinition()?.ui?.title ??
+      this.resourceDefinition()?.ui?.listView?.resourceTitle?.label ??
       this.resourceDefinition()?.entityCollection ??
       '',
   );
   defaultDescription = computed(
     () =>
-      this.resourceDefinition()?.ui?.description ??
+      this.resourceDefinition()?.ui?.listView?.resourceDescription?.label ??
       `This page displays the created ${this.resourceDefinition()?.entityCollection} in your environment`,
   );
   resourceDefinition = computed(() => this.context().resourceDefinition);


### PR DESCRIPTION
The `generic-list-view` component always displayed `entityCollection` as the page heading and description (e.g. "Accounts" even on the `/workspaces` page), with no way to override it from ContentConfiguration.

This adds optional `title` and `description` fields to `UIDefinition` so ContentConfiguration authors can set a custom heading and subtitle per resource list.

- `resourceDefinition.ui.title` overrides the page heading (falls back to `entityCollection`)
- `resourceDefinition.ui.description` overrides the subtitle (falls back to the default "This page displays the created X in your environment")