### PR TITLE
fix: adapt GraphQL input type names to gateway's new naming convention

### DIFF
--- a/projects/lib/services/resource/resource.service.ts
+++ b/projects/lib/services/resource/resource.service.ts
@@ -12,6 +12,7 @@ import {
   ResourceSubscriptionResult,
 } from '@platform-mesh/portal-ui-lib/models';
 import {
+  buildGraphQLInputTypeName,
   buildResourcePath,
   getResourceValueByJsonPath,
   getValueByPath,
@@ -392,7 +393,7 @@ export class ResourceService {
           ...(isNamespaced && {
             namespace: { type: 'String', value: namespace },
           }),
-          object: { type: `${entity}Input!`, value: resource },
+          object: { type: `${buildGraphQLInputTypeName(apiGroup, version, entity)}!`, value: resource },
         },
         fields: ['__typename'],
       },
@@ -442,7 +443,7 @@ export class ResourceService {
           }),
           name: { type: 'String!', value: resource.metadata.name },
           object: {
-            type: `${entity}Input!`,
+            type: `${buildGraphQLInputTypeName(apiGroup, version, entity)}!`,
             value: cleanResource,
           },
         },

--- a/projects/lib/utils/utils/build-graphql-input-type-name.spec.ts
+++ b/projects/lib/utils/utils/build-graphql-input-type-name.spec.ts
@@ -1,0 +1,136 @@
+import { buildGraphQLInputTypeName } from './build-graphql-input-type-name';
+
+describe('buildGraphQLInputTypeName', () => {
+  describe('core API types (empty group)', () => {
+    it('should produce V1Kind_Input for core v1 types', () => {
+      expect(buildGraphQLInputTypeName(undefined, 'v1', 'ConfigMap')).toBe(
+        'V1ConfigMap_Input',
+      );
+      expect(buildGraphQLInputTypeName(undefined, 'v1', 'Pod')).toBe(
+        'V1Pod_Input',
+      );
+      expect(buildGraphQLInputTypeName(undefined, 'v1', 'Secret')).toBe(
+        'V1Secret_Input',
+      );
+      expect(buildGraphQLInputTypeName(undefined, 'v1', 'Service')).toBe(
+        'V1Service_Input',
+      );
+      expect(buildGraphQLInputTypeName(undefined, 'v1', 'Namespace')).toBe(
+        'V1Namespace_Input',
+      );
+    });
+
+    it('should handle empty string group as no group', () => {
+      expect(buildGraphQLInputTypeName('', 'v1', 'ConfigMap')).toBe(
+        'V1ConfigMap_Input',
+      );
+    });
+  });
+
+  describe('apps group', () => {
+    it('should produce AppsV1Kind_Input for apps/v1 types', () => {
+      expect(buildGraphQLInputTypeName('apps', 'v1', 'Deployment')).toBe(
+        'AppsV1Deployment_Input',
+      );
+      expect(buildGraphQLInputTypeName('apps', 'v1', 'StatefulSet')).toBe(
+        'AppsV1StatefulSet_Input',
+      );
+      expect(buildGraphQLInputTypeName('apps', 'v1', 'DaemonSet')).toBe(
+        'AppsV1DaemonSet_Input',
+      );
+      expect(buildGraphQLInputTypeName('apps', 'v1', 'ReplicaSet')).toBe(
+        'AppsV1ReplicaSet_Input',
+      );
+    });
+  });
+
+  describe('networking.k8s.io group', () => {
+    it('should produce NetworkingK8sIoV1Kind_Input', () => {
+      expect(
+        buildGraphQLInputTypeName('networking.k8s.io', 'v1', 'Ingress'),
+      ).toBe('NetworkingK8sIoV1Ingress_Input');
+      expect(
+        buildGraphQLInputTypeName('networking.k8s.io', 'v1', 'NetworkPolicy'),
+      ).toBe('NetworkingK8sIoV1NetworkPolicy_Input');
+    });
+  });
+
+  describe('batch group', () => {
+    it('should produce BatchV1Kind_Input', () => {
+      expect(buildGraphQLInputTypeName('batch', 'v1', 'Job')).toBe(
+        'BatchV1Job_Input',
+      );
+      expect(buildGraphQLInputTypeName('batch', 'v1', 'CronJob')).toBe(
+        'BatchV1CronJob_Input',
+      );
+    });
+  });
+
+  describe('autoscaling group', () => {
+    it('should produce AutoscalingV1Kind_Input', () => {
+      expect(
+        buildGraphQLInputTypeName(
+          'autoscaling',
+          'v1',
+          'HorizontalPodAutoscaler',
+        ),
+      ).toBe('AutoscalingV1HorizontalPodAutoscaler_Input');
+    });
+  });
+
+  describe('custom CRD groups', () => {
+    it('should handle custom.io group', () => {
+      expect(buildGraphQLInputTypeName('custom.io', 'v1', 'Component')).toBe(
+        'CustomIoV1Component_Input',
+      );
+    });
+
+    it('should handle groups with hyphens', () => {
+      expect(
+        buildGraphQLInputTypeName('my-custom.example.io', 'v1beta1', 'Widget'),
+      ).toBe('MyCustomExampleIoV1beta1Widget_Input');
+    });
+
+    it('should handle groups starting with a digit', () => {
+      expect(
+        buildGraphQLInputTypeName('3scale.net', 'v1', 'APIProduct'),
+      ).toBe('3scaleNetV1APIProduct_Input');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle version without group', () => {
+      expect(buildGraphQLInputTypeName(undefined, 'v1alpha1', 'TestKind')).toBe(
+        'V1alpha1TestKind_Input',
+      );
+    });
+
+    it('should handle group without version', () => {
+      expect(buildGraphQLInputTypeName('apps', undefined, 'Deployment')).toBe(
+        'AppsDeployment_Input',
+      );
+    });
+
+    it('should handle neither group nor version', () => {
+      expect(buildGraphQLInputTypeName(undefined, undefined, 'TestKind')).toBe(
+        'TestKind_Input',
+      );
+    });
+
+    it('should handle core_platform_mesh_io style groups', () => {
+      expect(
+        buildGraphQLInputTypeName(
+          'core_platform_mesh_io',
+          'v1alpha1',
+          'AccountInfo',
+        ),
+      ).toBe('CorePlatformMeshIoV1alpha1AccountInfo_Input');
+    });
+
+    it('should handle core_kcp_io style groups', () => {
+      expect(
+        buildGraphQLInputTypeName('core_kcp_io', 'v1alpha1', 'LogicalCluster'),
+      ).toBe('CoreKcpIoV1alpha1LogicalCluster_Input');
+    });
+  });
+});

--- a/projects/lib/utils/utils/build-graphql-input-type-name.ts
+++ b/projects/lib/utils/utils/build-graphql-input-type-name.ts
@@ -1,0 +1,35 @@
+function sanitizeGroup(group: string): string {
+  let sanitized = group.replace(/[^a-zA-Z0-9]/g, '_');
+  if (/^[0-9]/.test(sanitized)) {
+    sanitized = '_' + sanitized;
+  }
+  return sanitized;
+}
+
+function pascalize(snakeCase: string): string {
+  return snakeCase
+    .split('_')
+    .filter((segment) => segment.length > 0)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join('');
+}
+
+export function buildGraphQLInputTypeName(
+  apiGroup: string | undefined,
+  version: string | undefined,
+  entity: string,
+): string {
+  let prefix: string;
+
+  if (apiGroup && version) {
+    prefix = pascalize(sanitizeGroup(apiGroup) + '_' + version);
+  } else if (apiGroup) {
+    prefix = pascalize(sanitizeGroup(apiGroup));
+  } else if (version) {
+    prefix = pascalize('_' + version);
+  } else {
+    return `${entity}_Input`;
+  }
+
+  return `${prefix}${entity}_Input`;
+}

--- a/projects/lib/utils/utils/index.ts
+++ b/projects/lib/utils/utils/index.ts
@@ -1,3 +1,4 @@
+export * from './build-graphql-input-type-name';
 export * from './build-resource-list-operation';
 export * from './columns-to-gql-fields';
 export * from './get-value-by-path';


### PR DESCRIPTION
## Summary

- Adapts to breaking changes in `kubernetes-graphql-gateway` PR #227 which makes GraphQL type names fully qualified with group+version prefix
- Adds `buildGraphQLInputTypeName` utility that constructs the new type names from `apiGroup`, `version`, and `entity` (e.g., `V1ConfigMap_Input`, `AppsV1Deployment_Input`)
- Updates `resource.service.ts` `create()` and `update()` methods to use the new naming

## Context

The gateway ([platform-mesh/kubernetes-graphql-gateway#227](https://github.com/platform-mesh/kubernetes-graphql-gateway/pull/227)) now uses deterministic, always-qualified type names:
- Core API (group=""): `V1ConfigMap`, `V1Pod`, etc.
- Other groups: `AppsV1Deployment`, `NetworkingK8sIoV1Ingress`, etc.
- Input suffix changed from `Input` to `_Input`

Previously this service constructed input types as `${entity}Input!` (e.g., `ConfigMapInput!`), which no longer resolves in the gateway schema.