### PR TITLE
feat: add tags display type to generic UI value cell

### DIFF
--- a/projects/lib/models/models/ui-definition.ts
+++ b/projects/lib/models/models/ui-definition.ts
@@ -1,4 +1,8 @@
-import { FormFieldDefinition, TableFieldDefinition } from '@openmfp/ngx';
+import {
+  FormFieldDefinition,
+  TableFieldDefinition,
+  UiSettings as NgxUiSettings,
+} from '@openmfp/ngx';
 
 export type {
   ButtonSettings,
@@ -8,9 +12,17 @@ export type {
   ModalSettings,
   PropertyField,
   TransformType,
-  UiSettings,
   ValueCellButtonClickEvent,
 } from '@openmfp/ngx';
+
+export interface TagSettings {
+  design?: 'Neutral' | 'Positive' | 'Critical' | 'Negative' | 'Information' | 'Set1' | 'Set2';
+  colorScheme?: string;
+}
+
+export type UiSettings = NgxUiSettings & {
+  tagSettings?: TagSettings;
+};
 
 export type FieldDefinition = TableFieldDefinition &
   Omit<FormFieldDefinition, 'name'> & {

--- a/projects/wc/src/app/components/generic-ui/value-cell/tag-list-value/tag-list-value.component.html
+++ b/projects/wc/src/app/components/generic-ui/value-cell/tag-list-value/tag-list-value.component.html
@@ -1,0 +1,10 @@
+<span class="tag-list" [attr.test-id]="testId()">
+  @for (tag of tags(); track tag) {
+    <ui5-tag
+      [design]="tagSettings()?.design ?? 'Neutral'"
+      [colorScheme]="tagSettings()?.colorScheme"
+      [hideStateIcon]="true"
+      [attr.test-id]="testId() + '-' + tag"
+    >{{ tag }}</ui5-tag>
+  }
+</span>

--- a/projects/wc/src/app/components/generic-ui/value-cell/tag-list-value/tag-list-value.component.scss
+++ b/projects/wc/src/app/components/generic-ui/value-cell/tag-list-value/tag-list-value.component.scss
@@ -1,0 +1,5 @@
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}

--- a/projects/wc/src/app/components/generic-ui/value-cell/tag-list-value/tag-list-value.component.ts
+++ b/projects/wc/src/app/components/generic-ui/value-cell/tag-list-value/tag-list-value.component.ts
@@ -1,0 +1,22 @@
+import {
+  CUSTOM_ELEMENTS_SCHEMA,
+  ChangeDetectionStrategy,
+  Component,
+  input,
+} from '@angular/core';
+import { Tag } from '@fundamental-ngx/ui5-webcomponents/tag';
+import { TagSettings } from '@platform-mesh/portal-ui-lib/models/models';
+
+@Component({
+  selector: 'pm-tag-list-value',
+  imports: [Tag],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  templateUrl: './tag-list-value.component.html',
+  styleUrl: './tag-list-value.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TagListValue {
+  tags = input.required<string[]>();
+  testId = input<string>('tag-list-value');
+  tagSettings = input<TagSettings | undefined>(undefined);
+}

--- a/projects/wc/src/app/components/generic-ui/value-cell/value-cell.component.html
+++ b/projects/wc/src/app/components/generic-ui/value-cell/value-cell.component.html
@@ -48,6 +48,12 @@
     }
   } @else if (displayType === 'img' && value()) {
     <img class="image-cell" [src]="value()" alt="Resource image" />
+  } @else if (displayType === 'tags' && tagsValue()) {
+    <pm-tag-list-value
+      [testId]="testId() + '-tags'"
+      [tags]="tagsValue()!"
+      [tagSettings]="tagSettings()"
+    ></pm-tag-list-value>
   } @else if (displayType === 'button') {
     @let buttonSettings = uiSettings()?.buttonSettings;
     <ui5-button

--- a/projects/wc/src/app/components/generic-ui/value-cell/value-cell.component.ts
+++ b/projects/wc/src/app/components/generic-ui/value-cell/value-cell.component.ts
@@ -3,6 +3,7 @@ import { getFieldValue } from '../../../utils/field-definition.utils';
 import { BooleanValue } from './boolean-value/boolean-value.component';
 import { LinkValue } from './link-value/link-value.component';
 import { SecretValue } from './secret-value/secret-value.component';
+import { TagListValue } from './tag-list-value/tag-list-value.component';
 import {
   CUSTOM_ELEMENTS_SCHEMA,
   ChangeDetectionStrategy,
@@ -22,7 +23,7 @@ import {
 
 @Component({
   selector: 'pm-value-cell',
-  imports: [Icon, BooleanValue, LinkValue, SecretValue, Button],
+  imports: [Icon, BooleanValue, LinkValue, SecretValue, Button, TagListValue],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
   templateUrl: './value-cell.component.html',
   styleUrls: ['./value-cell.component.scss'],
@@ -50,6 +51,7 @@ export class ValueCellComponent<T extends GenericResource> {
     ...this.cssCustomization(),
     ...this.cssRules(),
   }));
+  tagSettings = computed(() => this.uiSettings()?.tagSettings);
 
   isBoolLike = computed(() => this.boolValue() !== undefined);
   isUrlValue = computed(() => this.checkValidUrl(this.stringValue()));
@@ -57,6 +59,7 @@ export class ValueCellComponent<T extends GenericResource> {
 
   boolValue = computed(() => this.normalizeBoolean(this.value()));
   stringValue = computed(() => this.normalizeString(this.value()));
+  tagsValue = computed(() => this.normalizeTagsArray(this.value()));
   isVisible = signal(false);
 
   toggleVisibility(e: Event): void {
@@ -81,6 +84,16 @@ export class ValueCellComponent<T extends GenericResource> {
     }
 
     return value;
+  }
+
+  private normalizeTagsArray(value: unknown): string[] | undefined {
+    if (Array.isArray(value) && value.length > 0) {
+      return value.map(String);
+    }
+    if (typeof value === 'string' && value.trim()) {
+      return value.split(',').map((t) => t.trim()).filter(Boolean);
+    }
+    return undefined;
   }
 
   private checkValidUrl(value: string | undefined): boolean {


### PR DESCRIPTION
Adds a new `displayAs: 'tags'` option to the generic UI engine that renders string array (or comma-separated string) field values as ui5-tag chip elements. Design and color scheme are configurable via uiSettings.tagSettings.