### PR TITLE
 fix: gate create-form namespace dropdown on resolved namespace (#472)

### DIFF
--- a/docs/readme-generic-ui.md
+++ b/docs/readme-generic-ui.md
@@ -61,7 +61,7 @@ In order to use the generic list view, you need to adjust the node’s `content-
 
 - `"createView"`: Defines the form for creating/updating resources
   - `"fields"`: Array of `FieldDefinition` objects defining form fields. Supports `"required"` flag to indicate mandatory fields. Use `"values"` to provide a static list of options, or `"dynamicValuesDefinition"` to fetch options via GraphQL query (requires `"gqlQuery"`, `"operation"`, `"key"` for display value, and `"value"` for actual value).
-  - for namespaced resources, when URL search param `namespace` is `-all-` (or missing), the create form automatically adds a required `metadata.namespace` field with dynamic namespace options.
+  - for namespaced resources, the create form automatically adds a required `metadata.namespace` field with dynamic namespace options **only when no namespace is already resolved** — i.e. no namespace is selected in the navigation context (`namespaceId`) and the URL search param `namespace` is `-all-` (or missing). When a namespace is already resolved it is reused on create, so the field is omitted.
 
 #### Field Definition Properties
 

--- a/projects/lib/services/resource/resource.service.ts
+++ b/projects/lib/services/resource/resource.service.ts
@@ -494,7 +494,7 @@ export class ResourceService {
       );
   }
 
-  private getNamespace(
+  getNamespace(
     nodeContext: ResourceNodeContext,
     resource?: Resource,
   ): string | undefined {

--- a/projects/wc/src/app/components/generic-ui/list-view/create-resource-modal/create-resource-modal.component.spec.ts
+++ b/projects/wc/src/app/components/generic-ui/list-view/create-resource-modal/create-resource-modal.component.spec.ts
@@ -191,6 +191,17 @@ describe('CreateResourceModalComponent', () => {
       expect(nsField).toBeUndefined();
     });
 
+    it('should not append a metadata.namespace field when a namespace is already resolved', async () => {
+      resourceService.getNamespace.mockReturnValue('default');
+      fixture.componentRef.setInput('context', namespacedContext);
+      fixture.detectChanges();
+      await component.open();
+      const nsField = component
+        .formFields()
+        .find((f) => f.name === 'metadata.namespace');
+      expect(nsField).toBeUndefined();
+    });
+
     it('should prefetch dynamic values and store them in formField.values', async () => {
       resourceService.list.mockReturnValue(
         of([

--- a/projects/wc/src/app/components/generic-ui/list-view/create-resource-modal/create-resource-modal.component.ts
+++ b/projects/wc/src/app/components/generic-ui/list-view/create-resource-modal/create-resource-modal.component.ts
@@ -219,7 +219,10 @@ export class CreateResourceModal {
   }
 
   private shouldAddNamespaceControl() {
-    return this.isNamespacedResource();
+    return (
+      this.isNamespacedResource() &&
+      !this.resourceService.getNamespace(this.context())
+    );
   }
 
   private checkFormValidity(): boolean {

--- a/projects/wc/src/app/components/generic-ui/list-view/resource-table-card/resource-table-card.component.spec.ts
+++ b/projects/wc/src/app/components/generic-ui/list-view/resource-table-card/resource-table-card.component.spec.ts
@@ -386,6 +386,47 @@ describe('ResourceTableCard', () => {
       ).toBeFalsy();
     });
 
+    const makeNamespacedCreateContext = () =>
+      (() => ({
+        resourceDefinition: {
+          entityCollection: 'clusters',
+          entity: 'Cluster',
+          apiGroup: 'core_k8s_io',
+          version: 'v1alpha1',
+          scope: 'Namespaced',
+          ui: {
+            createView: { fields: [{ property: 'metadata.name' }] },
+            listView: { fields: [] },
+          },
+        },
+      })) as any;
+
+    it('should not add a metadata.namespace field when a namespace is already resolved', () => {
+      mockResourceService.getNamespace.mockReturnValue('default');
+      const newFixture = TestBed.createComponent(ResourceTableCard);
+      const newComponent = newFixture.componentInstance;
+      newComponent.context = makeNamespacedCreateContext();
+      newComponent.LuigiClient = makeLuigiClient();
+      newFixture.detectChanges();
+      const properties = newComponent
+        .createFormFields()
+        .map((f) => f.property);
+      expect(properties).not.toContain('metadata.namespace');
+    });
+
+    it('should add a metadata.namespace field when no namespace is resolved', () => {
+      mockResourceService.getNamespace.mockReturnValue(undefined);
+      const newFixture = TestBed.createComponent(ResourceTableCard);
+      const newComponent = newFixture.componentInstance;
+      newComponent.context = makeNamespacedCreateContext();
+      newComponent.LuigiClient = makeLuigiClient();
+      newFixture.detectChanges();
+      const properties = newComponent
+        .createFormFields()
+        .map((f) => f.property);
+      expect(properties).toContain('metadata.namespace');
+    });
+
     it('should set required error for empty required field', () => {
       const newFixture = TestBed.createComponent(ResourceTableCard);
       const newComponent = newFixture.componentInstance;

--- a/projects/wc/src/app/components/generic-ui/list-view/resource-table-card/resource-table-card.component.ts
+++ b/projects/wc/src/app/components/generic-ui/list-view/resource-table-card/resource-table-card.component.ts
@@ -112,7 +112,11 @@ export class ResourceTableCard {
 
   createFormFields = computed(() => {
     let fields = this.resourceDefinition()?.ui?.createView?.fields || [];
-    if (this.hasUiCreateViewFields() && this.isNamespaced()) {
+    if (
+      this.hasUiCreateViewFields() &&
+      this.isNamespaced() &&
+      !this.resourceService.getNamespace(this.context())
+    ) {
       fields = [
         ...fields,
         {


### PR DESCRIPTION
 ## What

  The generic create-resource forms added a required **"Namespace"** dropdown to every namespaced resource, even when a namespace
  was already resolved from the nav (`namespaceId`) or URL (`?namespace=`). On submit `ResourceService.getNamespace()` resolves
  the namespace regardless, so the dropdown had **no effect** — it was misleading.

  ## Fix

  Gate the namespace field on the resolved namespace, reusing the same `getNamespace()` resolver that runs on submit, in **both**
  create surfaces:

  - `create-resource-modal` — `shouldAddNamespaceControl()`
  - `resource-table-card` — `createFormFields`

  The field still appears at the `-all-`/account level (`getNamespace() === undefined`), where the user must pick one.

  ## Changes

  - Expose `ResourceService.getNamespace()` (`private` → public) for reuse
  - Regression tests for both surfaces (hidden when resolved, shown when not)
  - Update `docs/readme-generic-ui.md`

  ## Testing

  `npm run test:wc` (398) + `npm run test:lib` (414) green.

Closes #472