### PR TITLE
fix(opensearch-list-view): use wildcard query when search term is empty

### DIFF
--- a/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.spec.ts
+++ b/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.spec.ts
@@ -150,7 +150,7 @@ describe('OpenSearchService', () => {
 
       const params = mockHttpClient.get.mock.calls[0][1]?.params as any;
       expect(params.get('resource')).toBe('testkinds');
-      expect(params.get('q')).toBe('');
+      expect(params.get('q')).toBe('*');
     });
 
     it('should handle a missing resourceDefinition gracefully when no resource is given', async () => {
@@ -280,8 +280,8 @@ describe('OpenSearchService', () => {
    * edge cases (malformed filter, empty inputs, escaping rules).
    */
   describe('buildLuceneQuery', () => {
-    it('returns "" when both q and filter are empty', () => {
-      expect(buildLuceneQuery('', undefined)).toBe('');
+    it('returns "*" when both q and filter are empty', () => {
+      expect(buildLuceneQuery('', undefined)).toBe('*');
     });
 
     it('returns q verbatim when filter is absent', () => {

--- a/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.ts
+++ b/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.ts
@@ -199,7 +199,7 @@ export function buildLuceneQuery(
   q: string,
   filter: string | undefined,
 ): string {
-  if (!filter) return q;
+  if (!filter) return q || '*';
 
   const eq = filter.indexOf('=');
   if (eq <= 0 || eq === filter.length - 1) return q;


### PR DESCRIPTION
## Summary

- When no search term or filter is provided (e.g. initial page load), `buildLuceneQuery` returned an empty string `""`
- The search service rejects `q=` with a 400 error: `invalid request: q is required`
- Fix: return `*` (match-all Lucene query) when both `q` and `filter` are empty

## Test plan

- [ ] Navigate to the Workspaces page — table should load with all workspaces (no 400 error)
- [ ] Type in the search box — filtered results should appear
- [ ] Clear the search box — all workspaces should return