### PR TITLE
fix(opensearch-list-view): expand custom_fields so metadata/spec properties resolve in table

### DIFF
--- a/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.spec.ts
+++ b/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.spec.ts
@@ -150,7 +150,7 @@ describe('OpenSearchService', () => {
 
       const params = mockHttpClient.get.mock.calls[0][1]?.params as any;
       expect(params.get('resource')).toBe('testkinds');
-      expect(params.get('q')).toBe('');
+      expect(params.get('q')).toBe('*');
     });
 
     it('should handle a missing resourceDefinition gracefully when no resource is given', async () => {
@@ -280,8 +280,8 @@ describe('OpenSearchService', () => {
    * edge cases (malformed filter, empty inputs, escaping rules).
    */
   describe('buildLuceneQuery', () => {
-    it('returns "" when both q and filter are empty', () => {
-      expect(buildLuceneQuery('', undefined)).toBe('');
+    it('returns "*" when both q and filter are empty', () => {
+      expect(buildLuceneQuery('', undefined)).toBe('*');
     });
 
     it('returns q verbatim when filter is absent', () => {

--- a/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.ts
+++ b/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.ts
@@ -199,7 +199,7 @@ export function buildLuceneQuery(
   q: string,
   filter: string | undefined,
 ): string {
-  if (!filter) return q;
+  if (!filter) return q || '*';
 
   const eq = filter.indexOf('=');
   if (eq <= 0 || eq === filter.length - 1) return q;

--- a/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.ts
+++ b/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.ts
@@ -30,6 +30,7 @@ export interface OpenSearchResourceSource extends Record<any, unknown> {
   default_fields: Record<string, unknown>;
   filterable_fields: Record<string, unknown>;
   semantic_fields: Record<string, unknown>;
+  custom_fields?: Record<string, unknown>;
 }
 
 export interface OpenSearchResource extends GenericResource {
@@ -99,6 +100,7 @@ export class OpenSearchService {
               ...r.source.default_fields,
               ...r.source.filterable_fields,
               ...r.source.semantic_fields,
+              ...r.source.custom_fields,
             }),
           })),
         })),


### PR DESCRIPTION
## Summary

- `custom_fields` in the OpenSearch response contains dot-notation properties like `metadata.name`, `spec.displayName`, `spec.type`
- These were not being expanded and merged into the result object, so `getResourceValueByJsonPath` could not resolve them — causing empty/warning cells in the table
- Fix: include `custom_fields` alongside `default_fields`, `filterable_fields`, and `semantic_fields` in the `expandDotNotation` spread
- Also adds `custom_fields` to the `OpenSearchResourceSource` interface

## Root cause

The search service stores resource-specific fields (name, spec fields, etc.) under `source.custom_fields` with dot-notation keys. The UI was only expanding `default_fields`, `filterable_fields`, and `semantic_fields` — missing `custom_fields` entirely.

## Related

- Follows up on #505 (empty query fix)