### PR TITLE
Adjust passing of the filter to the open search endopint

### DIFF
--- a/projects/wc/src/app/components/generic-ui/opensearch-list-view/open-search-resource-table-card/open-search-resource-table-card.component.ts
+++ b/projects/wc/src/app/components/generic-ui/opensearch-list-view/open-search-resource-table-card/open-search-resource-table-card.component.ts
@@ -47,8 +47,8 @@ import { Subscription } from 'rxjs';
  *   feature toggle.
  * - Owns the search-text + scope filter state. Each active filter is
  *   reflected in the URL as `?<filter.property>=<filter.value>` (one clean
- *   query param per filter), and the backend receives the same pair as
- *   `filter=<property>=<value>` in the request body.
+ *   query param per filter), and the backend receives it as the search API's
+ *   native `filter.<field>=<value>` query param.
  *
  * On mount, `q` and any URL param whose key matches a filter tab's `property`
  * (and whose value matches that tab's `value`) are pushed to the host card

--- a/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.spec.ts
+++ b/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.spec.ts
@@ -1,8 +1,4 @@
-import {
-  OpenSearchRequest,
-  OpenSearchService,
-  buildLuceneQuery,
-} from './open-search.service';
+import { OpenSearchRequest, OpenSearchService } from './open-search.service';
 import { HttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { LuigiCoreService } from '@openmfp/portal-ui-lib';
@@ -192,32 +188,13 @@ describe('OpenSearchService', () => {
     });
 
     /**
-     * The adapter folds the caller's `filter: "property=value"` shape into a
-     * single Lucene URI-search `q` param. These tests pin the wire shape end
-     * to end so a regression here (e.g. someone reintroducing a separate
-     * `filter=` param) fails loudly.
+     * The adapter forwards the caller's `filter: "field=value"` shape as the
+     * search API's native `filter.<field>=<value>` query param, leaving `q` as
+     * the free-text term. These tests pin the wire shape end to end so a
+     * regression (e.g. someone folding filters back into `q`) fails loudly.
      */
-    describe('filter → Lucene q translation', () => {
-      it('folds filter alone into q as property:value', async () => {
-        mockHttpClient.get.mockReturnValue(
-          of({ results: [], source: 'os', nextCursor: '' }) as any,
-        );
-
-        await firstValueFrom(
-          service.asReadResources().list(
-            baseContext,
-            {},
-            { q: '', resource: 'testkinds', filter: 'metadata.namespace=default' },
-          ),
-        );
-
-        const params = mockHttpClient.get.mock.calls[0][1]?.params as any;
-        expect(params.get('q')).toBe('metadata.namespace:default');
-        // No stale `filter` param on the wire.
-        expect(params.has('filter')).toBe(false);
-      });
-
-      it('combines free-text q and filter with AND', async () => {
+    describe('filter → filter.<field> query param', () => {
+      it('sends the filter as filter.<field>=<value> and leaves q untouched', async () => {
         mockHttpClient.get.mockReturnValue(
           of({ results: [], source: 'os', nextCursor: '' }) as any,
         );
@@ -231,7 +208,29 @@ describe('OpenSearchService', () => {
         );
 
         const params = mockHttpClient.get.mock.calls[0][1]?.params as any;
-        expect(params.get('q')).toBe('oprt AND metadata.namespace:default');
+        expect(params.get('q')).toBe('oprt');
+        expect(params.get('filter.metadata.namespace')).toBe('default');
+        // The filter is not folded into q, and there is no bare `filter` param.
+        expect(params.get('q')).not.toContain('AND');
+        expect(params.has('filter')).toBe(false);
+      });
+
+      it('sends filter.<field> even when q is empty (q defaults to "*")', async () => {
+        mockHttpClient.get.mockReturnValue(
+          of({ results: [], source: 'os', nextCursor: '' }) as any,
+        );
+
+        await firstValueFrom(
+          service.asReadResources().list(
+            baseContext,
+            {},
+            { q: '', resource: 'testkinds', filter: 'metadata.namespace=default' },
+          ),
+        );
+
+        const params = mockHttpClient.get.mock.calls[0][1]?.params as any;
+        expect(params.get('q')).toBe('*');
+        expect(params.get('filter.metadata.namespace')).toBe('default');
       });
 
       it('sends only q when filter is absent', async () => {
@@ -252,10 +251,9 @@ describe('OpenSearchService', () => {
         expect(params.has('filter')).toBe(false);
       });
 
-      it('escapes Lucene-reserved characters in filter values', async () => {
-        // Hyphen is a Lucene reserved char (means "MUST NOT"). `kube-system`
-        // as a raw term would silently exclude documents matching `system`
-        // instead of finding a namespace literally called `kube-system`.
+      it('preserves reserved characters verbatim in the filter value', async () => {
+        // No Lucene escaping any more — `kube-system` is sent as-is because
+        // exact-match filters are a separate param, not part of the query DSL.
         mockHttpClient.get.mockReturnValue(
           of({ results: [], source: 'os', nextCursor: '' }) as any,
         );
@@ -269,62 +267,49 @@ describe('OpenSearchService', () => {
         );
 
         const params = mockHttpClient.get.mock.calls[0][1]?.params as any;
-        expect(params.get('q')).toBe('metadata.namespace:kube\\-system');
+        expect(params.get('filter.metadata.namespace')).toBe('kube-system');
       });
     });
   });
 
   /**
-   * Direct unit tests for the exported Lucene-composition helper. The
-   * adapter-level tests above already cover the happy path; these lock down
-   * edge cases (malformed filter, empty inputs, escaping rules).
+   * Direct unit tests for the filter-string parser. The adapter-level tests
+   * above cover the happy path; these lock down edge cases (malformed filter,
+   * empty inputs, values containing `=`). `parseFilter` is a private method, so
+   * it's invoked through the instance.
    */
-  describe('buildLuceneQuery', () => {
-    it('returns "*" when both q and filter are empty', () => {
-      expect(buildLuceneQuery('', undefined)).toBe('*');
+  describe('parseFilter', () => {
+    const parse = (filter: string | undefined) =>
+      (service as any).parseFilter(filter) as Record<string, string>;
+
+    it('returns an empty object when the filter is undefined', () => {
+      expect(parse(undefined)).toEqual({});
     });
 
-    it('returns q verbatim when filter is absent', () => {
-      expect(buildLuceneQuery('foo', undefined)).toBe('foo');
+    it('parses "field=value" into a single-entry map', () => {
+      expect(parse('k=v')).toEqual({ k: 'v' });
     });
 
-    it('returns just the filter clause when q is empty', () => {
-      expect(buildLuceneQuery('', 'k=v')).toBe('k:v');
+    it('treats a filter without `=` as absent', () => {
+      expect(parse('nofilter')).toEqual({});
     });
 
-    it('joins q and filter with AND', () => {
-      expect(buildLuceneQuery('foo', 'k=v')).toBe('foo AND k:v');
-    });
-
-    it('treats a filter without `=` as absent (returns q alone)', () => {
-      expect(buildLuceneQuery('foo', 'nofilter')).toBe('foo');
-    });
-
-    it('treats an empty-property filter as absent', () => {
-      // Leading `=` → property slice is "" → discarded.
-      expect(buildLuceneQuery('foo', '=v')).toBe('foo');
+    it('treats an empty-field filter as absent', () => {
+      expect(parse('=v')).toEqual({});
     });
 
     it('treats an empty-value filter as absent', () => {
-      // Trailing `=` → value slice is "" → discarded.
-      expect(buildLuceneQuery('foo', 'k=')).toBe('foo');
-    });
-
-    it('escapes reserved characters in the value', () => {
-      // `-` reserved (MUST NOT), `:` reserved (field separator), `*` reserved (wildcard).
-      expect(buildLuceneQuery('', 'k=a-b:c*')).toBe('k:a\\-b\\:c\\*');
+      expect(parse('k=')).toEqual({});
     });
 
     it('splits on the FIRST `=` so values may contain `=`', () => {
-      // A value with `=` inside — the split is only on the leftmost `=`.
-      expect(buildLuceneQuery('', 'k=v=w')).toBe('k:v=w');
+      expect(parse('k=v=w')).toEqual({ k: 'v=w' });
     });
 
-    it('does not escape the property (dot is literal in field names)', () => {
-      // `metadata.namespace` is a Lucene field name, dots are not reserved.
-      expect(buildLuceneQuery('', 'metadata.namespace=default')).toBe(
-        'metadata.namespace:default',
-      );
+    it('keeps reserved characters in the value verbatim', () => {
+      expect(parse('metadata.namespace=kube-system')).toEqual({
+        'metadata.namespace': 'kube-system',
+      });
     });
   });
 

--- a/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.ts
+++ b/projects/wc/src/app/components/generic-ui/opensearch-list-view/services/open-search.service.ts
@@ -14,11 +14,12 @@ import { EMPTY, Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 export interface OpenSearchRequest {
-  q: string; // (required): free-text query, may include Lucene syntax like `field:value AND field2:value2`
+  q: string; // (required): free-text query
   resource?: string; // (optional): plural resource name; if omitted, searches across all resources
   limit?: number; // (optional): default 20, max 100
   cursor?: string; // (optional): opaque pagination cursor
   page?: number; // (optional): 1-based page number for page-based pagination
+  filters?: Record<string, string>; // (optional, repeatable): exact-match filters, sent as `filter.<field>=<value>`; requires `resource`
 }
 
 export interface OpenSearchResult {
@@ -51,22 +52,6 @@ export interface OpenSearchResource extends GenericResource {
   source: OpenSearchResourceSource;
 }
 
-function expandDotNotation(fields: Record<string, unknown>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(fields)) {
-    const parts = key.split('.');
-    let node = result;
-    for (let i = 0; i < parts.length - 1; i++) {
-      if (node[parts[i]] === undefined || typeof node[parts[i]] !== 'object') {
-        node[parts[i]] = {};
-      }
-      node = node[parts[i]] as Record<string, unknown>;
-    }
-    node[parts[parts.length - 1]] = value;
-  }
-  return result;
-}
-
 @Injectable({ providedIn: 'root' })
 export class OpenSearchService {
   private luigiCoreService = inject(LuigiCoreService);
@@ -97,7 +82,7 @@ export class OpenSearchService {
           ...response,
           results: response.results.map((r) => ({
             ...r,
-            ...expandDotNotation({
+            ...this.expandDotNotation({
               ...r.source.default_fields,
               ...r.source.filterable_fields,
               ...r.source.semantic_fields,
@@ -127,6 +112,10 @@ export class OpenSearchService {
       params = params.set('resource', request.resource);
     }
 
+    for (const [field, value] of Object.entries(request.filters ?? {})) {
+      params = params.set(`filter.${field}`, value);
+    }
+
     return params;
   }
 
@@ -142,13 +131,12 @@ export class OpenSearchService {
    * be swapped for ResourceService behind a feature toggle. OpenSearch has no
    * subscription channel, so `subscribe` returns an EMPTY observable.
    *
-   * The caller passes `params.filter` in the shape `"<property>=<value>"` (the
-   * shape produced by {@link OpenSearchResourceTableCard.list}). We translate
-   * that to OpenSearch's native Lucene URI-search syntax and fold it into the
-   * single `q` param — for example, `{ q: 'oprt', filter: 'metadata.namespace=default' }`
-   * becomes `q=oprt AND metadata.namespace:default` on the wire. Reserved
-   * Lucene characters in the value are escaped so unusual namespace names
-   * (e.g. `kube-system`, which contains a Lucene-reserved `-`) still work.
+   * The caller passes `params.filter` in the shape `"<field>=<value>"` (the
+   * shape produced by {@link OpenSearchResourceTableCard.list}). We forward it
+   * as the search API's native `filter.<field>=<value>` query param — for
+   * example, `{ q: 'oprt', filter: 'metadata.namespace=default' }` becomes
+   * `q=oprt&filter.metadata.namespace=default` on the wire. Per the API,
+   * `filter.<field>` requires `resource` to be set.
    */
   asReadResources(): ReadResources {
     return {
@@ -158,63 +146,62 @@ export class OpenSearchService {
         params: ReadResourcesParams,
       ): Observable<ReadResourcesResult> => {
         const request: OpenSearchRequest = {
-          q: buildLuceneQuery(params.q ?? '', params.filter),
+          q: params.q || '*',
           resource:
             params.resource ?? nodeContext.resourceDefinition?.entityCollection,
           limit: pagination.limit,
           cursor: pagination.cursor,
           page: pagination.page,
+          filters: this.parseFilter(params.filter),
         };
 
         return this.listResources(nodeContext, request).pipe(
-          map((result): ReadResourcesResult => ({
-            items: result?.results ?? [],
-            nextCursor: result?.nextCursor,
-          })),
+          map(
+            (result): ReadResourcesResult => ({
+              items: result?.results ?? [],
+              nextCursor: result?.nextCursor,
+            }),
+          ),
         );
       },
       subscribe: (): Observable<ReadResourcesSubscriptionResult | undefined> =>
         EMPTY,
     };
   }
-}
 
-/**
- * Lucene reserved characters that must be backslash-escaped inside term
- * values. See the OpenSearch / Lucene query-string documentation. `\` must
- * come first in the regex character class so its own escape isn't broken.
- */
-const LUCENE_RESERVED = /([\\+\-!(){}\[\]^"~*?:/]|&&|\|\|)/g;
+  /**
+   * Parses the `"<field>=<value>"` filter string used across the read-resources
+   * contract into a `{ field: value }` map suitable for `filter.<field>=<value>`
+   * query params. Returns an empty object for absent or malformed input (no `=`,
+   * empty field, or empty value).
+   */
+  private parseFilter(filter: string | undefined): Record<string, string> {
+    if (!filter) return {};
 
-/** Escape a value for use inside a Lucene `field:value` term clause. */
-function escapeLuceneValue(value: string): string {
-  return value.replace(LUCENE_RESERVED, '\\$1');
-}
+    const eq = filter.indexOf('=');
+    if (eq <= 0 || eq === filter.length - 1) return {};
 
-/**
- * Combines a free-text search term and an optional `"<property>=<value>"`
- * exact-match filter into a single Lucene URI-search query string.
- *
- * Rules:
- * - No filter, no q → `""` (matches everything).
- * - Only q → `q` verbatim.
- * - Only filter → `property:escapedValue`.
- * - Both → `q AND property:escapedValue`.
- * - Malformed filter (no `=`, empty property, or empty value) → treated as
- *   "no filter" and `q` is returned alone.
- */
-export function buildLuceneQuery(
-  q: string,
-  filter: string | undefined,
-): string {
-  if (!filter) return q || '*';
+    return { [filter.slice(0, eq)]: filter.slice(eq + 1) };
+  }
 
-  const eq = filter.indexOf('=');
-  if (eq <= 0 || eq === filter.length - 1) return q;
-
-  const property = filter.slice(0, eq);
-  const value = filter.slice(eq + 1);
-  const clause = `${property}:${escapeLuceneValue(value)}`;
-
-  return q ? `${q} AND ${clause}` : clause;
+  private expandDotNotation(
+    fields: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(fields)) {
+      const parts = key.split('.');
+      let node = result;
+      for (let i = 0; i < parts.length - 1; i++) {
+        if (
+          node[parts[i]] === undefined ||
+          typeof node[parts[i]] !== 'object'
+        ) {
+          node[parts[i]] = {};
+        }
+        node = node[parts[i]] as Record<string, unknown>;
+      }
+      node[parts[parts.length - 1]] = value;
+    }
+    return result;
+  }
 }


### PR DESCRIPTION
Adhere to the expected api

## API

### Search endpoint

`GET /rest/v1/search?q=<query>&mode=<lexical|semantic>&limit=<n>&cursor=<opaque>&resource=<plural>&filter.<field>=<value>`

Query params:

- `q` (required): free-text query
- `mode` (optional): search mode; `lexical` by default, `semantic` to use OpenSearch neural search on configured semantic fields
- `resource` (optional for `lexical`, required for `semantic`): plural resource name; lexical mode can search across all resources, semantic mode must target a single resource
- `filter.<field>` (optional, repeatable): exact-match filters; requires `resource`
- `limit` (optional): default `20`, max `100`
- `cursor` (optional): opaque pagination cursor


https://github.com/platform-mesh/platform-mesh/tree/main/services/search-service