### PR TITLE
fix: resolve gateway auth token per request, not at client creation

### DIFF
--- a/projects/lib/services/resource/apollo-factory.spec.ts
+++ b/projects/lib/services/resource/apollo-factory.spec.ts
@@ -3,7 +3,7 @@ import type { GatewayService } from './gateway.service';
 import { ResourceNodeContext } from './resource-node-context';
 import { TestBed } from '@angular/core/testing';
 import { ApolloLink, InMemoryCache, execute } from '@apollo/client/core';
-import { LuigiCoreService } from '@openmfp/portal-ui-lib';
+import { AuthService, LuigiCoreService } from '@openmfp/portal-ui-lib';
 import { Apollo } from 'apollo-angular';
 import { HttpLink } from 'apollo-angular/http';
 import { parse } from 'graphql';
@@ -22,6 +22,7 @@ describe('ApolloFactory', () => {
   let createClient: typeof import('graphql-sse').createClient;
   let factory: ApolloFactory;
   let luigiCoreServiceMock: any;
+  let authServiceMock: any;
   let httpLinkMock: any;
   let gatewayServiceMock: MockedObject<GatewayService>;
 
@@ -42,12 +43,16 @@ describe('ApolloFactory', () => {
       }),
       getGlobalContext: vi.fn().mockReturnValue({ token: 'fake-token' }),
     };
+    authServiceMock = {
+      getToken: vi.fn().mockReturnValue(undefined),
+    };
     gatewayServiceMock = mock<GatewayService>();
     TestBed.configureTestingModule({
       providers: [
         ApolloFactoryClass,
         { provide: HttpLink, useValue: httpLinkMock },
         { provide: LuigiCoreService, useValue: luigiCoreServiceMock },
+        { provide: AuthService, useValue: authServiceMock },
         { provide: GatewayServiceToken, useValue: gatewayServiceMock },
       ],
     });
@@ -109,6 +114,57 @@ describe('ApolloFactory', () => {
 
     const headers = clientOptions.headers();
     expect(headers).toEqual({ Authorization: 'Bearer fake-token' });
+  });
+
+  it('resolves the token per request, preferring the live AuthService value', () => {
+    const createClientMock = createClient as MockedFunction<
+      typeof createClient
+    >;
+    createClientMock.mockClear();
+    createClientMock.mockReturnValue({
+      subscribe: vi.fn().mockReturnValue(() => void 0),
+    } as unknown as ReturnType<typeof createClient>);
+
+    // client created BEFORE any token exists (the sticky-401 scenario,
+    // apeirora/showroom#296)
+    const nodeContext = { token: undefined } as unknown as ResourceNodeContext;
+    (factory as any).createApolloOptions(nodeContext, false);
+    const clientOptions = createClientMock.mock.calls[0][0] as unknown as {
+      headers: () => Record<string, string>;
+    };
+
+    authServiceMock.getToken.mockReturnValue('live-token-1');
+    expect(clientOptions.headers()).toEqual({
+      Authorization: 'Bearer live-token-1',
+    });
+
+    // a refreshed token must be picked up by later requests on the SAME client
+    authServiceMock.getToken.mockReturnValue('live-token-2');
+    expect(clientOptions.headers()).toEqual({
+      Authorization: 'Bearer live-token-2',
+    });
+  });
+
+  it('falls back to the node context token when AuthService has none', () => {
+    const createClientMock = createClient as MockedFunction<
+      typeof createClient
+    >;
+    createClientMock.mockClear();
+    createClientMock.mockReturnValue({
+      subscribe: vi.fn().mockReturnValue(() => void 0),
+    } as unknown as ReturnType<typeof createClient>);
+
+    authServiceMock.getToken.mockReturnValue(undefined);
+    const nodeContext = {
+      token: 'context-token',
+    } as unknown as ResourceNodeContext;
+    (factory as any).createApolloOptions(nodeContext, false);
+    const clientOptions = createClientMock.mock.calls[0][0] as unknown as {
+      headers: () => Record<string, string>;
+    };
+    expect(clientOptions.headers()).toEqual({
+      Authorization: 'Bearer context-token',
+    });
   });
 
   it('should pass readFromParentKcpPath flag to SSE url resolver', () => {

--- a/projects/lib/services/resource/apollo-factory.spec.ts
+++ b/projects/lib/services/resource/apollo-factory.spec.ts
@@ -125,8 +125,7 @@ describe('ApolloFactory', () => {
       subscribe: vi.fn().mockReturnValue(() => void 0),
     } as unknown as ReturnType<typeof createClient>);
 
-    // client created BEFORE any token exists (the sticky-401 scenario,
-    // apeirora/showroom#296)
+    // client created BEFORE any token exists (the sticky-401 scenario)
     const nodeContext = { token: undefined } as unknown as ResourceNodeContext;
     (factory as any).createApolloOptions(nodeContext, false);
     const clientOptions = createClientMock.mock.calls[0][0] as unknown as {

--- a/projects/lib/services/resource/apollo-factory.ts
+++ b/projects/lib/services/resource/apollo-factory.ts
@@ -2,6 +2,7 @@ import { GatewayService } from './gateway.service';
 import { ResourceNodeContext } from './resource-node-context';
 import { HttpHeaders } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
+import { AuthService } from '@openmfp/portal-ui-lib';
 import {
   type ApolloClientOptions,
   ApolloLink,
@@ -51,6 +52,7 @@ const noopZone = {
 export class ApolloFactory {
   private httpLink = inject(HttpLink);
   private gatewayService = inject(GatewayService);
+  private authService = inject(AuthService);
 
   public readonly apollo = (
     nodeContext: ResourceNodeContext,
@@ -60,6 +62,18 @@ export class ApolloFactory {
       noopZone,
       this.createApolloOptions(nodeContext, readFromParentKcpPath),
     );
+
+  /**
+   * The token must be resolved per request, never captured at client
+   * creation: a client built before the shell delivers the token would
+   * otherwise send "Bearer undefined" for its whole lifetime (silent 401s,
+   * empty views until a hard reload - apeirora/showroom#296). Prefer the
+   * live AuthService value so token refreshes are picked up too; fall back
+   * to the node context snapshot.
+   */
+  private resolveToken(nodeContext: ResourceNodeContext): string | undefined {
+    return this.authService.getToken() || nodeContext.token;
+  }
 
   private createApolloOptions(
     nodeContext: ResourceNodeContext,
@@ -76,7 +90,7 @@ export class ApolloFactory {
         uri: () =>
           this.gatewayService.getGatewayUrl(nodeContext, readFromParentKcpPath),
         headers: baseHeaders
-          .set('Authorization', `Bearer ${nodeContext.token}`)
+          .set('Authorization', `Bearer ${this.resolveToken(nodeContext)}`)
           .set('Accept', 'charset=utf-8'),
       };
     });
@@ -93,7 +107,7 @@ export class ApolloFactory {
         url: () =>
           this.gatewayService.getGatewayUrl(nodeContext, readFromParentKcpPath),
         headers: () => ({
-          Authorization: `Bearer ${nodeContext.token}`,
+          Authorization: `Bearer ${this.resolveToken(nodeContext)}`,
         }),
       }),
       this.httpLink.create({}),

--- a/projects/lib/services/resource/apollo-factory.ts
+++ b/projects/lib/services/resource/apollo-factory.ts
@@ -67,9 +67,9 @@ export class ApolloFactory {
    * The token must be resolved per request, never captured at client
    * creation: a client built before the shell delivers the token would
    * otherwise send "Bearer undefined" for its whole lifetime (silent 401s,
-   * empty views until a hard reload - apeirora/showroom#296). Prefer the
-   * live AuthService value so token refreshes are picked up too; fall back
-   * to the node context snapshot.
+   * empty views until a hard reload). Prefer the live AuthService value so
+   * token refreshes are picked up too; fall back to the node context
+   * snapshot.
    */
   private resolveToken(nodeContext: ResourceNodeContext): string | undefined {
     return this.authService.getToken() || nodeContext.token;


### PR DESCRIPTION
## Problem

`ApolloFactory` captures `nodeContext.token` when the client is created and bakes it into the `Authorization` header. A micro-frontend that constructs its Apollo client before the shell has delivered the token sends `Bearer undefined` for the client's whole lifetime: every query 401s **silently** and views render empty until a hard reload happens to re-create the client with a warm token. Token refreshes are equally invisible to long-lived clients.

Most visible victim: the marketplace catalog intermittently rendering empty ("reload fixes it"). Full analysis with live iframe instrumentation in apeirora/showroom#296 — this is the origin half; the response-caching half that made those 401s sticky is openmfp/portal-server-lib#356.

Notably the gateway **URL** was already resolved lazily per request (`uri: () => ...`) — the token was the only value frozen at creation time.

## Fix

Resolve the token inside the per-request context/header callbacks (HTTP link and SSE link both), preferring the live `AuthService.getToken()` value and falling back to the node context snapshot.

## Testing

- new spec: token resolved per request — a client created **before** any token exists picks up `AuthService` tokens on later requests, including refreshed values on the same client
- new spec: falls back to `nodeContext.token` when `AuthService` has none
- full lib suite: 30/30 files, 431/431 tests green
