### PR TITLE
fix: default opensearch list view to 20 rows per page

### DIFF
--- a/projects/wc/src/app/components/generic-ui/opensearch-list-view/open-search-resource-table-card/open-search-resource-table-card.component.spec.ts
+++ b/projects/wc/src/app/components/generic-ui/opensearch-list-view/open-search-resource-table-card/open-search-resource-table-card.component.spec.ts
@@ -102,7 +102,7 @@ describe('OpenSearchResourceTableCard', () => {
     expect(mockReadResources.list).toHaveBeenCalledWith(
       expect.objectContaining({ resourceDefinition: expect.any(Object) }),
       expect.objectContaining({
-        limit: 50,
+        limit: 20,
         page: 1,
       }),
       expect.objectContaining({
@@ -171,8 +171,8 @@ describe('OpenSearchResourceTableCard', () => {
         remainingItemCount: 3,
       });
       listSubject.complete();
-      // (2-1)*50 + 2 items + 3 remaining = 55
-      expect(component.totalItemsCount()).toBe(55);
+      // (2-1)*20 + 2 items + 3 remaining = 25
+      expect(component.totalItemsCount()).toBe(25);
     });
 
     it('config should reflect columns, pagination, currentPage, and pager mode', () => {
@@ -224,7 +224,7 @@ describe('OpenSearchResourceTableCard', () => {
 
       const lastCall = mockReadResources.list.mock.calls.at(-1)!;
       expect(lastCall[1]).toEqual(
-        expect.objectContaining({ page: 3, limit: 50 }),
+        expect.objectContaining({ page: 3, limit: 20 }),
       );
     });
 

--- a/projects/wc/src/app/components/generic-ui/opensearch-list-view/open-search-resource-table-card/open-search-resource-table-card.component.ts
+++ b/projects/wc/src/app/components/generic-ui/opensearch-list-view/open-search-resource-table-card/open-search-resource-table-card.component.ts
@@ -99,7 +99,7 @@ export class OpenSearchResourceTableCard implements OnInit {
     return columns;
   });
 
-  paginationLimit = signal<number>(50);
+  paginationLimit = signal<number>(20);
   currentPage = signal<number>(this.pageFromUrl());
   totalItemsCount = signal<number>(0);
 


### PR DESCRIPTION
## Summary

- Change the default pagination limit for the OpenSearch list view from **50** to **20** rows per page.

The default is set in `OpenSearchResourceTableCard.paginationLimit` and flows into `tableConfig.paginationLimit` for `<mfp-declarative-table-card>`.

## Test plan

- [x] Updated unit tests that asserted the previous default of 50 (`open-search-resource-table-card.component.spec.ts`).
- [x] `ng test wc` for the affected spec passes (41/41).