### PR TITLE
fix: guard against non-string token from AuthService.getToken()

### DIFF
--- a/projects/lib/services/resource/apollo-factory.ts
+++ b/projects/lib/services/resource/apollo-factory.ts
@@ -72,7 +72,8 @@ export class ApolloFactory {
    * snapshot.
    */
   private resolveToken(nodeContext: ResourceNodeContext): string | undefined {
-    return this.authService.getToken() || nodeContext.token;
+    const token = this.authService.getToken();
+    return (typeof token === 'string' && token) ? token : nodeContext.token;
   }
 
   private createApolloOptions(


### PR DESCRIPTION
## Summary

- `AuthService.getToken()` from `@openmfp/portal-ui-lib` returns `{}` (empty object) instead of `undefined` when `authData` is not initialized
- `{}` is truthy, so `getToken() || nodeContext.token` never reached the fallback
- This caused `Authorization: Bearer [object Object]` headers, resulting in 401 errors on GraphQL requests
- Added a `typeof` guard: only use the token if it is a non-empty string; otherwise fall back to `nodeContext.token`

Root cause reported upstream at openmfp/portal-ui-lib#678.

## Test plan

- Navigate to a page that fires GraphQL requests (e.g., `/teams`, `/workspaces`)
- Verify `Authorization` header contains a valid bearer token (not `[object Object]`)
- Verify requests return 200, not 401