### PR TITLE
fix: bump @openmfp/portal-ui-lib to 0.194.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@fundamental-ngx/ui5-webcomponents-fiori": "0.59.1",
         "@openmfp/config-prettier": "0.9.2",
         "@openmfp/ngx": "0.18.0",
-        "@openmfp/portal-ui-lib": "0.194.10",
+        "@openmfp/portal-ui-lib": "^0.194.14",
         "@vitest/coverage-v8": "4.1.10",
         "cpx2": "9.0.0",
         "flatted": "3.4.2",
@@ -5769,9 +5769,9 @@
       }
     },
     "node_modules/@openmfp/portal-ui-lib": {
-      "version": "0.194.10",
-      "resolved": "https://registry.npmjs.org/@openmfp/portal-ui-lib/-/portal-ui-lib-0.194.10.tgz",
-      "integrity": "sha512-WzvnrSuN7l9hOoRG009VUr//ZQXiVUAQUGNSaZdlEhfINvwmhRM4TwmNDVMNi6xWvXRkeyrzeSFGQd47DY105g==",
+      "version": "0.194.14",
+      "resolved": "https://registry.npmjs.org/@openmfp/portal-ui-lib/-/portal-ui-lib-0.194.14.tgz",
+      "integrity": "sha512-ySG1nlGL5omR9HgYqBsWaJuS6yswJcxwZlcPoJyGHJMrSgoLlaFrKMPvhr3MQPsqY0Knwm2cDsNEYdEtI27NZA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@fundamental-ngx/ui5-webcomponents-fiori": "0.59.1",
     "@openmfp/config-prettier": "0.9.2",
     "@openmfp/ngx": "0.18.0",
-    "@openmfp/portal-ui-lib": "0.194.10",
+    "@openmfp/portal-ui-lib": "^0.194.14",
     "@vitest/coverage-v8": "4.1.10",
     "cpx2": "9.0.0",
     "flatted": "3.4.2",


### PR DESCRIPTION
## Summary

- Bumps `@openmfp/portal-ui-lib` from `0.194.10` to `0.194.14`
- Picks up openmfp/portal-ui-lib#679: `getToken()` now returns `undefined` instead of `{}` when auth data is not set
- Fixes `Authorization: Bearer [object Object]` headers that caused 401 errors on GraphQL requests

Also closes #558 (the defensive guard is no longer needed once the upstream fix is in).

## Test plan

- Navigate to a page that fires GraphQL requests (e.g., `/teams`, `/workspaces`)
- Verify `Authorization` header contains a valid bearer token (not `[object Object]`)
- Verify requests return 200, not 401