### PR TITLE
feat(portal-options): add persistent provider panels

### DIFF
--- a/projects/lib/portal-options/persistent-panel/open-persistent-panel.listener.spec.ts
+++ b/projects/lib/portal-options/persistent-panel/open-persistent-panel.listener.spec.ts
@@ -1,0 +1,60 @@
+import { OpenPersistentPanelListener } from './open-persistent-panel.listener';
+import { PersistentPanelService } from './persistent-panel.service';
+import { OPEN_PERSISTENT_PANEL_MESSAGE } from './persistent-panel.types';
+import { Injector, runInInjectionContext } from '@angular/core';
+import { LuigiCoreService, NodeContext } from '@openmfp/portal-ui-lib';
+
+describe('OpenPersistentPanelListener', () => {
+  it('opens the registered provider UI with bounded Portal context', () => {
+    const panelService = {
+      currentTarget: vi.fn().mockReturnValue({
+        organization: 'showroom',
+        account: 'ig-1',
+        workspacePath: 'root:orgs:showroom:ig-1',
+      }),
+      open: vi.fn(),
+    };
+    const luigiCoreService = {
+      getGlobalContext: vi.fn().mockReturnValue({
+        organization: 'showroom',
+        token: 'must-not-leak',
+      }),
+    };
+    const injector = Injector.create({
+      providers: [
+        { provide: PersistentPanelService, useValue: panelService },
+        { provide: LuigiCoreService, useValue: luigiCoreService },
+      ],
+    });
+    const listener = runInInjectionContext(
+      injector,
+      () => new OpenPersistentPanelListener(),
+    );
+
+    expect(listener.messageId()).toBe(OPEN_PERSISTENT_PANEL_MESSAGE);
+    listener.onCustomMessageReceived(
+      { id: OPEN_PERSISTENT_PANEL_MESSAGE, url: 'https://attacker.example' },
+      undefined,
+      {
+        viewUrl: 'https://provider.example.test/panel',
+        context: {
+          persistentPanel: { id: 'provider.tools', title: 'Provider tools' },
+        } as unknown as NodeContext,
+      },
+    );
+
+    expect(panelService.open).toHaveBeenCalledWith(
+      {
+        id: 'provider.tools',
+        title: 'Provider tools',
+        url: 'https://provider.example.test/panel',
+        origin: 'https://provider.example.test',
+      },
+      {
+        organization: 'showroom',
+        account: 'ig-1',
+        workspacePath: 'root:orgs:showroom:ig-1',
+      },
+    );
+  });
+});

--- a/projects/lib/portal-options/persistent-panel/open-persistent-panel.listener.ts
+++ b/projects/lib/portal-options/persistent-panel/open-persistent-panel.listener.ts
@@ -1,0 +1,43 @@
+import { PersistentPanelService } from './persistent-panel.service';
+import {
+  OPEN_PERSISTENT_PANEL_MESSAGE,
+  mergePersistentPanelTargets,
+  parsePersistentPanelConfig,
+  persistentPanelTarget,
+} from './persistent-panel.types';
+import { Injectable, inject } from '@angular/core';
+import {
+  CustomMessageListener,
+  LuigiCoreService,
+  NodeContext,
+} from '@openmfp/portal-ui-lib';
+
+@Injectable({ providedIn: 'root' })
+export class OpenPersistentPanelListener implements CustomMessageListener {
+  private readonly luigiCoreService = inject(LuigiCoreService);
+  private readonly persistentPanelService = inject(PersistentPanelService);
+
+  messageId(): string {
+    return OPEN_PERSISTENT_PANEL_MESSAGE;
+  }
+
+  onCustomMessageReceived(
+    customMessage: Record<string, unknown>,
+    _microFrontend: unknown,
+    microFrontendNode: { context?: NodeContext; viewUrl?: string } | undefined,
+  ): void {
+    const config = parsePersistentPanelConfig(
+      customMessage as { id: string },
+      microFrontendNode,
+      new URL(document.baseURI).origin,
+    );
+    const target = mergePersistentPanelTargets(
+      this.persistentPanelService.currentTarget(),
+      persistentPanelTarget(
+        this.luigiCoreService.getGlobalContext(),
+        microFrontendNode?.context,
+      ),
+    );
+    this.persistentPanelService.open(config, target);
+  }
+}

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.html
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.html
@@ -1,0 +1,67 @@
+<section
+  class="persistent-panel"
+  role="complementary"
+  aria-labelledby="persistent-panel-title"
+  [attr.aria-hidden]="state() === 'hidden'"
+  [class.maximized]="state() === 'maximized'"
+  [class.open]="state() !== 'hidden'"
+>
+  <header class="persistent-panel-header">
+    <div>
+      <h2 id="persistent-panel-title">{{ title() }}</h2>
+      @if (closeError()) {
+      <p role="alert">{{ closeError() }}</p>
+      }
+    </div>
+    <div class="persistent-panel-actions">
+      <button
+        aria-label="Toggle panel size"
+        [attr.aria-pressed]="state() === 'maximized'"
+        title="Toggle panel size"
+        type="button"
+        (click)="toggleSize()"
+      >
+        @if (state() === 'maximized') { ◲ } @else { ◱ }
+      </button>
+      <button
+        aria-label="Collapse panel"
+        title="Collapse panel"
+        type="button"
+        (click)="collapse()"
+      >
+        —
+      </button>
+      <button
+        aria-label="Close panel"
+        title="Close panel"
+        type="button"
+        (click)="close()"
+      >
+        ×
+      </button>
+    </div>
+  </header>
+  @if (source()) {
+  <iframe
+    #panelFrame
+    class="persistent-panel-frame"
+    referrerpolicy="no-referrer"
+    sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
+    [src]="source()"
+    [title]="title()"
+    (load)="frameLoaded()"
+  ></iframe>
+  }
+</section>
+
+@if (state() === 'hidden' && source() && !closing()) {
+<button
+  #reopenButton
+  class="persistent-panel-reopen"
+  aria-label="Open provider panel"
+  type="button"
+  (click)="expand()"
+>
+  {{ title() }}
+</button>
+}

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.scss
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.scss
@@ -1,0 +1,98 @@
+:host {
+  --pm-panel-header-height: 3rem;
+  font-family: var(--sapFontFamily, '72', Arial, sans-serif);
+}
+
+.persistent-panel {
+  position: fixed;
+  top: var(--luigi__shellbar--height, 3.25rem);
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
+  display: none;
+  width: min(34rem, 100vw);
+  background: var(--sapBackgroundColor, #fff);
+  border-left: 1px solid var(--sapGroup_ContentBorderColor, #d9d9d9);
+  box-shadow: -0.25rem 0 1rem rgb(0 0 0 / 12%);
+}
+
+.persistent-panel.open {
+  display: grid;
+  grid-template-rows: var(--pm-panel-header-height) 1fr;
+}
+
+.persistent-panel.maximized {
+  left: 4.25rem;
+  width: auto;
+}
+
+.persistent-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0.75rem 0 1rem;
+  color: var(--sapShell_TextColor, #1d2d3e);
+  background: var(--sapShell_Background, #fff);
+  border-bottom: 1px solid var(--sapGroup_ContentBorderColor, #d9d9d9);
+}
+
+.persistent-panel-header h2 {
+  overflow: hidden;
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.persistent-panel-header p {
+  margin: 0;
+  color: var(--sapNegativeTextColor, #aa0808);
+  font-size: 0.75rem;
+}
+
+.persistent-panel-actions {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.persistent-panel-actions button,
+.persistent-panel-reopen {
+  min-width: 2rem;
+  min-height: 2rem;
+  color: var(--sapButton_TextColor, #0064d9);
+  background: transparent;
+  border: 0;
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+
+.persistent-panel-actions button:hover,
+.persistent-panel-reopen:hover {
+  background: var(--sapButton_Lite_Hover_Background, #eaecee);
+}
+
+.persistent-panel-frame {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.persistent-panel-reopen {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1000;
+  padding: 0.5rem 0.75rem;
+  color: var(--sapButton_Emphasized_TextColor, #fff);
+  background: var(--sapButton_Emphasized_Background, #0070f2);
+  box-shadow: 0 0.25rem 0.75rem rgb(0 0 0 / 20%);
+}
+
+@media (max-width: 600px) {
+  .persistent-panel,
+  .persistent-panel.maximized {
+    left: 0;
+    width: 100vw;
+  }
+}

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.service.spec.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.service.spec.ts
@@ -1,0 +1,53 @@
+import { PersistentPanelService } from './persistent-panel.service';
+import { TestBed } from '@angular/core/testing';
+
+const config = {
+  id: 'provider.tools',
+  title: 'Provider tools',
+  url: 'https://provider.example.test/panel',
+  origin: 'https://provider.example.test',
+};
+
+describe('PersistentPanelService', () => {
+  let service: PersistentPanelService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PersistentPanelService);
+  });
+
+  afterEach(() => {
+    service.destroy();
+  });
+
+  it('creates one panel host and reuses it for subsequent opens', () => {
+    service.open(config, { organization: 'showroom' });
+    const panelHost = document.querySelector('pm-persistent-panel');
+
+    expect(panelHost?.querySelector('iframe')).not.toBeNull();
+    expect(panelHost?.textContent).toContain('Provider tools');
+
+    service.open(config, { organization: 'showroom', account: 'ig-1' });
+
+    expect(document.querySelectorAll('pm-persistent-panel')).toHaveLength(1);
+    expect(service.currentTarget()).toEqual({
+      organization: 'showroom',
+      account: 'ig-1',
+    });
+  });
+
+  it('tracks navigation before a panel is opened and clears state on destroy', () => {
+    service.updateTarget({ organization: 'showroom', account: 'ig-1' });
+    expect(service.currentTarget()).toEqual({
+      organization: 'showroom',
+      account: 'ig-1',
+    });
+
+    service.open(config, service.currentTarget());
+    service.destroy();
+    service.destroy();
+
+    expect(service.currentTarget()).toEqual({});
+    expect(document.querySelector('pm-persistent-panel')).toBeNull();
+  });
+});

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.service.spec.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.service.spec.ts
@@ -37,10 +37,14 @@ describe('PersistentPanelService', () => {
   });
 
   it('tracks navigation before a panel is opened and clears state on destroy', () => {
-    service.updateTarget({ organization: 'showroom', account: 'ig-1' });
+    service.beginTargetUpdate()({
+      organization: 'showroom',
+      accountId: 'ig-1',
+    });
     expect(service.currentTarget()).toEqual({
       organization: 'showroom',
       account: 'ig-1',
+      workspacePath: 'root:orgs:showroom:ig-1',
     });
 
     service.open(config, service.currentTarget());
@@ -49,5 +53,67 @@ describe('PersistentPanelService', () => {
 
     expect(service.currentTarget()).toEqual({});
     expect(document.querySelector('pm-persistent-panel')).toBeNull();
+  });
+
+  it('normalizes raw Portal context and clears stale descendant scope', () => {
+    service.beginTargetUpdate()({
+      organization: 'showroom',
+      accountId: 'ig-1',
+      namespaceId: 'apps',
+      token: 'must-not-leak',
+    });
+    expect(service.currentTarget()).toEqual({
+      organization: 'showroom',
+      account: 'ig-1',
+      workspacePath: 'root:orgs:showroom:ig-1',
+      namespace: 'apps',
+    });
+
+    service.beginTargetUpdate()({ organization: 'showroom' });
+    expect(service.currentTarget()).toEqual({ organization: 'showroom' });
+  });
+
+  it('ignores completion from an older navigation', () => {
+    const completeFirstNavigation = service.beginTargetUpdate();
+    const completeSecondNavigation = service.beginTargetUpdate();
+
+    completeSecondNavigation({
+      organization: 'showroom',
+      accountId: 'account-b',
+    });
+    completeFirstNavigation({
+      organization: 'showroom',
+      accountId: 'account-a',
+    });
+
+    expect(service.currentTarget()).toEqual({
+      organization: 'showroom',
+      account: 'account-b',
+      workspacePath: 'root:orgs:showroom:account-b',
+    });
+  });
+
+  it('uses the resolver-enriched path for a nested account', () => {
+    service.beginTargetUpdate()({
+      organization: 'showroom',
+      accountId: 'child',
+      accountPath: 'parent:child',
+      kcpPath: 'root:orgs:showroom:parent:child',
+    });
+
+    expect(service.currentTarget()).toEqual({
+      organization: 'showroom',
+      account: 'child',
+      workspacePath: 'root:orgs:showroom:parent:child',
+    });
+  });
+
+  it('invalidates a pending navigation when destroyed', () => {
+    const completeNavigation = service.beginTargetUpdate();
+
+    service.destroy();
+    completeNavigation({ organization: 'showroom', accountId: 'ig-1' });
+
+    expect(service.currentTarget()).toEqual({});
   });
 });

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.service.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.service.ts
@@ -2,6 +2,7 @@ import { PersistentPanelComponent } from './persistent-panel';
 import {
   PersistentPanelConfig,
   PersistentPanelTarget,
+  persistentPanelTarget,
 } from './persistent-panel.types';
 import {
   ApplicationRef,
@@ -19,6 +20,7 @@ export class PersistentPanelService implements OnDestroy {
   private readonly environmentInjector = inject(EnvironmentInjector);
   private panelRef: ComponentRef<PersistentPanelComponent> | null = null;
   private target: PersistentPanelTarget = {};
+  private targetUpdateSequence = 0;
 
   open(config: PersistentPanelConfig, target: PersistentPanelTarget): void {
     this.target = target;
@@ -38,7 +40,18 @@ export class PersistentPanelService implements OnDestroy {
     this.panelRef.changeDetectorRef.detectChanges();
   }
 
-  updateTarget(target: PersistentPanelTarget): void {
+  beginTargetUpdate(): (context: Record<string, unknown>) => void {
+    const targetUpdateSequence = ++this.targetUpdateSequence;
+    return (context) => {
+      if (targetUpdateSequence !== this.targetUpdateSequence) {
+        return;
+      }
+      this.updateTarget(context);
+    };
+  }
+
+  private updateTarget(context: Record<string, unknown>): void {
+    const target = persistentPanelTarget({}, context);
     this.target = target;
     this.panelRef?.instance.updateTarget(target);
   }
@@ -48,6 +61,7 @@ export class PersistentPanelService implements OnDestroy {
   }
 
   destroy(): void {
+    this.targetUpdateSequence += 1;
     if (this.panelRef) {
       const host = this.panelRef.location.nativeElement as HTMLElement;
       this.appRef.detachView(this.panelRef.hostView);

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.service.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.service.ts
@@ -1,0 +1,64 @@
+import { PersistentPanelComponent } from './persistent-panel';
+import {
+  PersistentPanelConfig,
+  PersistentPanelTarget,
+} from './persistent-panel.types';
+import {
+  ApplicationRef,
+  ComponentRef,
+  EnvironmentInjector,
+  Injectable,
+  OnDestroy,
+  createComponent,
+  inject,
+} from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class PersistentPanelService implements OnDestroy {
+  private readonly appRef = inject(ApplicationRef);
+  private readonly environmentInjector = inject(EnvironmentInjector);
+  private panelRef: ComponentRef<PersistentPanelComponent> | null = null;
+  private target: PersistentPanelTarget = {};
+
+  open(config: PersistentPanelConfig, target: PersistentPanelTarget): void {
+    this.target = target;
+    if (!this.panelRef) {
+      this.panelRef = createComponent(PersistentPanelComponent, {
+        environmentInjector: this.environmentInjector,
+      });
+      this.appRef.attachView(this.panelRef.hostView);
+      document.body.appendChild(
+        this.panelRef.location.nativeElement as HTMLElement,
+      );
+    }
+    this.panelRef.instance.open(config, target);
+    // createComponent() is outside a template tree, so it has no initial
+    // render until change detection is run explicitly. Subsequent signal
+    // updates are scheduled normally once the view has been initialized.
+    this.panelRef.changeDetectorRef.detectChanges();
+  }
+
+  updateTarget(target: PersistentPanelTarget): void {
+    this.target = target;
+    this.panelRef?.instance.updateTarget(target);
+  }
+
+  currentTarget(): PersistentPanelTarget {
+    return structuredClone(this.target);
+  }
+
+  destroy(): void {
+    if (this.panelRef) {
+      const host = this.panelRef.location.nativeElement as HTMLElement;
+      this.appRef.detachView(this.panelRef.hostView);
+      this.panelRef.destroy();
+      host.remove();
+      this.panelRef = null;
+    }
+    this.target = {};
+  }
+
+  ngOnDestroy(): void {
+    this.destroy();
+  }
+}

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.spec.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.spec.ts
@@ -1,0 +1,329 @@
+import { PersistentPanelComponent } from './persistent-panel';
+import { PROVIDER_PANEL_MESSAGE } from './persistent-panel.types';
+import { ElementRef, Injector, runInInjectionContext } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+
+const providerOrigin = 'https://provider.example.test';
+const config = {
+  id: 'provider.tools',
+  title: 'Provider tools',
+  url: `${providerOrigin}/panel`,
+  origin: providerOrigin,
+};
+
+describe('PersistentPanelComponent', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('posts context and lifecycle messages only to the registered origin', () => {
+    const postMessage = vi.fn();
+    const component = createPanel();
+    component.panelFrame = frameWith(postMessage);
+
+    component.open(config, { organization: 'showroom' });
+    component.frameLoaded();
+    component.updateTarget({ organization: 'showroom', account: 'ig-1' });
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.ready },
+        origin: providerOrigin,
+        source: component.panelFrame.nativeElement.contentWindow,
+      }),
+    );
+    component.close();
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: PROVIDER_PANEL_MESSAGE.context }),
+      providerOrigin,
+    );
+    expect(postMessage).toHaveBeenLastCalledWith(
+      { type: PROVIDER_PANEL_MESSAGE.close, requestId: 1 },
+      providerOrigin,
+    );
+    component.ngOnDestroy();
+  });
+
+  it('supports collapse, expand, and maximize without destroying the iframe', () => {
+    const component = createPanel();
+    component.open(config, {});
+
+    component.collapse();
+    expect(component.state()).toBe('hidden');
+    component.expand();
+    expect(component.state()).toBe('expanded');
+    component.toggleSize();
+    expect(component.state()).toBe('maximized');
+    component.toggleSize();
+    expect(component.state()).toBe('expanded');
+    expect(component.source()).not.toBeNull();
+    component.ngOnDestroy();
+  });
+
+  it('retains the iframe until the provider acknowledges cleanup', () => {
+    const frameWindow = { postMessage: vi.fn() } as unknown as WindowProxy;
+    const component = createPanel();
+    component.panelFrame = new ElementRef({
+      contentWindow: frameWindow,
+    } as HTMLIFrameElement);
+    component.open(config, { organization: 'showroom' });
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.ready },
+        origin: providerOrigin,
+        source: frameWindow,
+      }),
+    );
+    component.close();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.closed, requestId: 1 },
+        origin: providerOrigin,
+        source: frameWindow,
+      }),
+    );
+
+    expect(component.closing()).toBe(false);
+    expect(component.source()).toBeNull();
+    component.ngOnDestroy();
+  });
+
+  it('accepts ready and request-close only from the registered frame', () => {
+    const postMessage = vi.fn();
+    const frameWindow = { postMessage } as unknown as WindowProxy;
+    const component = createPanel();
+    component.panelFrame = new ElementRef({
+      contentWindow: frameWindow,
+    } as HTMLIFrameElement);
+    component.open(config, {});
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.ready },
+        origin: providerOrigin,
+        source: frameWindow,
+      }),
+    );
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.requestClose },
+        origin: providerOrigin,
+        source: frameWindow,
+      }),
+    );
+
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: PROVIDER_PANEL_MESSAGE.context }),
+      providerOrigin,
+    );
+    expect(component.closing()).toBe(true);
+    component.ngOnDestroy();
+  });
+
+  it('waits for provider readiness before requesting cleanup', () => {
+    const postMessage = vi.fn();
+    const frameWindow = { postMessage } as unknown as WindowProxy;
+    const component = createPanel();
+    component.panelFrame = new ElementRef({
+      contentWindow: frameWindow,
+    } as HTMLIFrameElement);
+    component.open(config, {});
+
+    component.close();
+    expect(postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: PROVIDER_PANEL_MESSAGE.close }),
+      providerOrigin,
+    );
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.ready },
+        origin: providerOrigin,
+        source: frameWindow,
+      }),
+    );
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.ready },
+        origin: providerOrigin,
+        source: frameWindow,
+      }),
+    );
+
+    expect(postMessage).toHaveBeenCalledTimes(1);
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: PROVIDER_PANEL_MESSAGE.close, requestId: 1 },
+      providerOrigin,
+    );
+    component.ngOnDestroy();
+  });
+
+  it('moves focus into, out of, and back to the panel deterministically', async () => {
+    const returnButton = document.createElement('button');
+    const reopenButton = document.createElement('button');
+    const iframe = document.createElement('iframe');
+    document.body.append(returnButton, reopenButton, iframe);
+    returnButton.focus();
+    const component = createPanel();
+    component.panelFrame = new ElementRef(iframe);
+    component.reopenButton = new ElementRef(reopenButton);
+
+    component.open(config, {});
+    await nextMicrotask();
+    expect(document.activeElement).toBe(iframe);
+
+    component.collapse();
+    await nextMicrotask();
+    expect(document.activeElement).toBe(reopenButton);
+
+    component.expand();
+    await nextMicrotask();
+    expect(document.activeElement).toBe(iframe);
+
+    component.close();
+    expect(document.activeElement).toBe(returnButton);
+
+    component.ngOnDestroy();
+    returnButton.remove();
+    reopenButton.remove();
+    iframe.remove();
+  });
+
+  it('ignores lifecycle messages from another source, origin, or shape', () => {
+    const frameWindow = { postMessage: vi.fn() } as unknown as WindowProxy;
+    const component = createPanel();
+    component.panelFrame = new ElementRef({
+      contentWindow: frameWindow,
+    } as HTMLIFrameElement);
+    component.open(config, {});
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.ready },
+        origin: providerOrigin,
+        source: frameWindow,
+      }),
+    );
+    component.close();
+
+    for (const event of [
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.closed, requestId: 1 },
+        origin: 'https://attacker.example',
+        source: frameWindow,
+      }),
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.closed, requestId: 1 },
+        origin: providerOrigin,
+        source: { postMessage: vi.fn() } as unknown as WindowProxy,
+      }),
+      new MessageEvent('message', {
+        data: [],
+        origin: providerOrigin,
+        source: frameWindow,
+      }),
+    ]) {
+      window.dispatchEvent(event);
+    }
+
+    expect(component.closing()).toBe(true);
+    expect(component.source()).not.toBeNull();
+    component.ngOnDestroy();
+  });
+
+  it('cancels stale close completion when the panel is reopened', () => {
+    vi.useFakeTimers();
+    const frameWindow = { postMessage: vi.fn() } as unknown as WindowProxy;
+    const component = createPanel();
+    component.panelFrame = new ElementRef({
+      contentWindow: frameWindow,
+    } as HTMLIFrameElement);
+    component.open(config, {});
+    component.close();
+
+    component.open(config, { account: 'team-a' });
+    vi.advanceTimersByTime(30_000);
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.closed, requestId: 1 },
+        origin: providerOrigin,
+        source: frameWindow,
+      }),
+    );
+
+    expect(component.closing()).toBe(false);
+    expect(component.source()).not.toBeNull();
+    expect(component.state()).toBe('expanded');
+    component.ngOnDestroy();
+  });
+
+  it('keeps an unresponsive iframe visible after the bounded timeout', () => {
+    vi.useFakeTimers();
+    const postMessage = vi.fn();
+    const component = createPanel();
+    component.panelFrame = frameWith(postMessage);
+    component.open(config, {});
+
+    component.close();
+    component.close();
+    vi.advanceTimersByTime(30_000);
+
+    expect(component.closing()).toBe(false);
+    expect(component.source()).not.toBeNull();
+    expect(component.state()).toBe('expanded');
+    expect(component.closeError()).toMatch(/cleanup is incomplete/i);
+    component.ngOnDestroy();
+  });
+
+  it('keeps the iframe visible when the provider reports cleanup failure', () => {
+    const frameWindow = { postMessage: vi.fn() } as unknown as WindowProxy;
+    const component = createPanel();
+    component.panelFrame = new ElementRef({
+      contentWindow: frameWindow,
+    } as HTMLIFrameElement);
+    component.open(config, {});
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.ready },
+        origin: providerOrigin,
+        source: frameWindow,
+      }),
+    );
+    component.close();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: PROVIDER_PANEL_MESSAGE.closeFailed, requestId: 1 },
+        origin: providerOrigin,
+        source: frameWindow,
+      }),
+    );
+
+    expect(component.closing()).toBe(false);
+    expect(component.source()).not.toBeNull();
+    expect(component.state()).toBe('expanded');
+    component.ngOnDestroy();
+  });
+});
+
+function createPanel(): PersistentPanelComponent {
+  const injector = Injector.create({
+    providers: [
+      {
+        provide: DomSanitizer,
+        useValue: { bypassSecurityTrustResourceUrl: (url: string) => url },
+      },
+    ],
+  });
+  return runInInjectionContext(injector, () => new PersistentPanelComponent());
+}
+
+function frameWith(postMessage: ReturnType<typeof vi.fn>) {
+  return new ElementRef({
+    contentWindow: { postMessage } as unknown as WindowProxy,
+  } as HTMLIFrameElement);
+}
+
+function nextMicrotask(): Promise<void> {
+  return new Promise((resolve) => queueMicrotask(resolve));
+}

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.ts
@@ -1,0 +1,277 @@
+import {
+  PROVIDER_PANEL_MESSAGE,
+  PersistentPanelConfig,
+  PersistentPanelTarget,
+} from './persistent-panel.types';
+import { CommonModule } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnDestroy,
+  ViewChild,
+  inject,
+  signal,
+} from '@angular/core';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+
+type PanelState = 'hidden' | 'expanded' | 'maximized';
+
+@Component({
+  selector: 'pm-persistent-panel',
+  imports: [CommonModule],
+  standalone: true,
+  templateUrl: './persistent-panel.html',
+  styleUrl: './persistent-panel.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PersistentPanelComponent implements OnDestroy {
+  @ViewChild('panelFrame') panelFrame?: ElementRef<HTMLIFrameElement>;
+  @ViewChild('reopenButton') reopenButton?: ElementRef<HTMLButtonElement>;
+
+  readonly state = signal<PanelState>('hidden');
+  readonly title = signal('');
+  readonly source = signal<SafeResourceUrl | null>(null);
+  readonly closing = signal(false);
+  readonly closeError = signal('');
+
+  private readonly sanitizer = inject(DomSanitizer);
+  private config: PersistentPanelConfig | null = null;
+  private target: PersistentPanelTarget = {};
+  private sequence = 0;
+  private closeSequence = 0;
+  private closeTimeout: number | null = null;
+  private closeRequestIdSent: number | null = null;
+  private destroyed = false;
+  private ready = false;
+  private returnFocusElement: HTMLElement | null = null;
+
+  constructor() {
+    window.addEventListener('message', this.onMessage);
+  }
+
+  ngOnDestroy(): void {
+    this.destroyed = true;
+    window.removeEventListener('message', this.onMessage);
+    this.clearCloseTimeout();
+  }
+
+  open(config: PersistentPanelConfig, target: PersistentPanelTarget): void {
+    if (this.closing()) {
+      this.closeSequence += 1;
+    }
+    this.clearCloseTimeout();
+    this.closeRequestIdSent = null;
+    this.closing.set(false);
+    this.closeError.set('');
+    const sourceChanged = this.config?.url !== config.url;
+    if (!this.source()) {
+      this.returnFocusElement =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+    }
+    if (sourceChanged) {
+      this.ready = false;
+    }
+    this.config = config;
+    this.target = structuredClone(target);
+    this.title.set(config.title);
+    if (sourceChanged || !this.source()) {
+      this.source.set(
+        this.sanitizer.bypassSecurityTrustResourceUrl(config.url),
+      );
+    }
+    this.state.set('expanded');
+    queueMicrotask(() => {
+      if (this.destroyed) {
+        return;
+      }
+      this.publishTarget();
+      this.focusPanel();
+    });
+  }
+
+  updateTarget(target: PersistentPanelTarget): void {
+    this.target = structuredClone(target);
+    this.publishTarget();
+  }
+
+  collapse(): void {
+    this.state.set('hidden');
+    queueMicrotask(() => {
+      if (this.destroyed) {
+        return;
+      }
+      this.reopenButton?.nativeElement.focus();
+    });
+  }
+
+  expand(): void {
+    this.state.set('expanded');
+    queueMicrotask(() => {
+      if (this.destroyed) {
+        return;
+      }
+      this.focusPanel();
+    });
+  }
+
+  toggleSize(): void {
+    this.state.update((state) =>
+      state === 'maximized' ? 'expanded' : 'maximized',
+    );
+  }
+
+  close(): void {
+    if (!this.source() || this.closing()) {
+      return;
+    }
+    this.closeSequence += 1;
+    const requestId = this.closeSequence;
+    this.closeRequestIdSent = null;
+    this.closing.set(true);
+    this.closeError.set('');
+    this.state.set('hidden');
+    this.focusReturnTarget();
+    this.requestCloseIfReady(requestId);
+    this.closeTimeout = window.setTimeout(() => {
+      this.failClose(requestId);
+    }, 30_000);
+  }
+
+  private failClose(requestId: number): void {
+    if (!this.closing() || requestId !== this.closeSequence) {
+      return;
+    }
+    this.clearCloseTimeout();
+    this.closeRequestIdSent = null;
+    this.closing.set(false);
+    this.closeError.set('Provider cleanup is incomplete. Try closing again.');
+    this.state.set('expanded');
+    queueMicrotask(() => {
+      if (this.destroyed) {
+        return;
+      }
+      this.focusPanel();
+    });
+  }
+
+  private finishClose(requestId: number): void {
+    if (
+      !this.closing() ||
+      requestId !== this.closeSequence ||
+      this.closeRequestIdSent !== requestId
+    ) {
+      return;
+    }
+    this.clearCloseTimeout();
+    this.closeRequestIdSent = null;
+    this.closing.set(false);
+    this.closeError.set('');
+    this.config = null;
+    this.ready = false;
+    this.source.set(null);
+    this.title.set('');
+    this.state.set('hidden');
+    this.focusReturnTarget();
+    this.returnFocusElement = null;
+  }
+
+  private clearCloseTimeout(): void {
+    if (this.closeTimeout !== null) {
+      window.clearTimeout(this.closeTimeout);
+      this.closeTimeout = null;
+    }
+  }
+
+  frameLoaded(): void {
+    this.publishTarget();
+  }
+
+  private publishTarget(): void {
+    if (!this.config) {
+      return;
+    }
+    this.sequence += 1;
+    this.post({
+      type: PROVIDER_PANEL_MESSAGE.context,
+      panelId: this.config.id,
+      sequence: this.sequence,
+      target: this.target,
+    });
+  }
+
+  private requestCloseIfReady(requestId: number): void {
+    if (
+      !this.ready ||
+      !this.closing() ||
+      requestId !== this.closeSequence ||
+      this.closeRequestIdSent === requestId
+    ) {
+      return;
+    }
+    this.closeRequestIdSent = requestId;
+    this.post({ type: PROVIDER_PANEL_MESSAGE.close, requestId });
+  }
+
+  private focusPanel(): void {
+    this.panelFrame?.nativeElement.focus?.();
+  }
+
+  private focusReturnTarget(): void {
+    if (this.returnFocusElement?.isConnected) {
+      this.returnFocusElement.focus();
+    }
+  }
+
+  private post(message: Record<string, unknown>): void {
+    if (!this.config) {
+      return;
+    }
+    this.panelFrame?.nativeElement.contentWindow?.postMessage(
+      message,
+      this.config.origin,
+    );
+  }
+
+  private readonly onMessage = (event: MessageEvent<unknown>): void => {
+    const frame = this.panelFrame?.nativeElement;
+    if (
+      !frame ||
+      event.source !== frame.contentWindow ||
+      event.origin !== this.config?.origin ||
+      !isRecord(event.data)
+    ) {
+      return;
+    }
+    if (event.data['type'] === PROVIDER_PANEL_MESSAGE.ready) {
+      this.ready = true;
+      if (this.closing()) {
+        this.requestCloseIfReady(this.closeSequence);
+      } else {
+        this.publishTarget();
+      }
+    }
+    if (event.data['type'] === PROVIDER_PANEL_MESSAGE.requestClose) {
+      this.close();
+    }
+    if (
+      event.data['type'] === PROVIDER_PANEL_MESSAGE.closeFailed &&
+      typeof event.data['requestId'] === 'number' &&
+      event.data['requestId'] === this.closeRequestIdSent
+    ) {
+      this.failClose(event.data['requestId']);
+    }
+    if (
+      event.data['type'] === PROVIDER_PANEL_MESSAGE.closed &&
+      typeof event.data['requestId'] === 'number'
+    ) {
+      this.finishClose(event.data['requestId']);
+    }
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.types.spec.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.types.spec.ts
@@ -1,0 +1,370 @@
+import {
+  OPEN_PERSISTENT_PANEL_MESSAGE,
+  mergePersistentPanelTargets,
+  parsePersistentPanelConfig,
+  persistentPanelTarget,
+} from './persistent-panel.types';
+
+const trustedNode = (viewUrl: string) => ({
+  viewUrl,
+  context: {
+    persistentPanel: { id: 'provider.tools', title: 'Provider tools' },
+  },
+});
+
+describe('persistent provider panel contract', () => {
+  it('derives the iframe URL and exact origin from the registered provider UI', () => {
+    expect(
+      parsePersistentPanelConfig(
+        {
+          id: OPEN_PERSISTENT_PANEL_MESSAGE,
+          panel: {
+            id: 'provider.tools',
+            title: 'Provider tools',
+            url: 'https://attacker.example/panel',
+          },
+        },
+        trustedNode('https://provider.example.test/panel?mode=embedded'),
+        'https://portal.example.test',
+      ),
+    ).toEqual({
+      id: 'provider.tools',
+      title: 'Provider tools',
+      url: 'https://provider.example.test/panel?mode=embedded',
+      origin: 'https://provider.example.test',
+    });
+  });
+
+  it('rejects a registered same-origin provider UI URL', () => {
+    expect(() =>
+      parsePersistentPanelConfig(
+        { id: OPEN_PERSISTENT_PANEL_MESSAGE },
+        trustedNode('/provider/panel'),
+        'https://portal.example.test',
+      ),
+    ).toThrow(/registered provider UI URL is invalid/i);
+  });
+
+  it('rejects a wrong message id', () => {
+    expect(() =>
+      parsePersistentPanelConfig(
+        { id: 'wrong.message' },
+        trustedNode('https://provider.example.test/panel'),
+        'https://portal.example.test',
+      ),
+    ).toThrow(/request is invalid/i);
+  });
+
+  it('rejects missing or invalid registered capability metadata', () => {
+    expect(() =>
+      parsePersistentPanelConfig(
+        { id: OPEN_PERSISTENT_PANEL_MESSAGE },
+        undefined,
+        'https://portal.example.test',
+      ),
+    ).toThrow(/registered persistent panel id/i);
+    expect(() =>
+      parsePersistentPanelConfig(
+        { id: OPEN_PERSISTENT_PANEL_MESSAGE },
+        {
+          viewUrl: 'https://provider.example.test/panel',
+          context: {
+            persistentPanel: { id: '../provider', title: 'Provider tools' },
+          },
+        },
+        'https://portal.example.test',
+      ),
+    ).toThrow(/registered persistent panel id/i);
+    expect(() =>
+      parsePersistentPanelConfig(
+        { id: OPEN_PERSISTENT_PANEL_MESSAGE },
+        {
+          viewUrl: 'https://provider.example.test/panel',
+          context: { persistentPanel: { id: 'provider.tools', title: '' } },
+        },
+        'https://portal.example.test',
+      ),
+    ).toThrow(/registered persistent panel title/i);
+  });
+
+  it('rejects a missing or unsafe registered provider UI URL', () => {
+    expect(() =>
+      parsePersistentPanelConfig(
+        { id: OPEN_PERSISTENT_PANEL_MESSAGE },
+        {
+          context: {
+            persistentPanel: { id: 'provider.tools', title: 'Provider tools' },
+          },
+        },
+        'https://portal.example.test',
+      ),
+    ).toThrow(/registered provider UI URL is missing/i);
+    expect(() =>
+      parsePersistentPanelConfig(
+        { id: OPEN_PERSISTENT_PANEL_MESSAGE },
+        trustedNode('javascript:alert(1)'),
+        'https://portal.example.test',
+      ),
+    ).toThrow(/registered provider UI URL is invalid/i);
+    expect(() =>
+      parsePersistentPanelConfig(
+        { id: OPEN_PERSISTENT_PANEL_MESSAGE },
+        trustedNode('https://user:password@provider.example.test/panel'),
+        'https://portal.example.test',
+      ),
+    ).toThrow(/registered provider UI URL is invalid/i);
+    expect(() =>
+      parsePersistentPanelConfig(
+        { id: OPEN_PERSISTENT_PANEL_MESSAGE },
+        trustedNode('http://provider.example.test/panel'),
+        'https://portal.example.test',
+      ),
+    ).toThrow(/registered provider UI URL is invalid/i);
+  });
+
+  it('derives identity only from trusted node metadata', () => {
+    expect(
+      parsePersistentPanelConfig(
+        {
+          id: OPEN_PERSISTENT_PANEL_MESSAGE,
+          panel: { id: 'attacker.panel', title: 'Impersonated UI' },
+        },
+        trustedNode('https://provider.example.test/panel'),
+        'https://portal.example.test',
+      ),
+    ).toMatchObject({ id: 'provider.tools', title: 'Provider tools' });
+  });
+
+  it('allows HTTP loopback only from an HTTP development Portal', () => {
+    expect(
+      parsePersistentPanelConfig(
+        { id: OPEN_PERSISTENT_PANEL_MESSAGE },
+        trustedNode('http://127.0.0.1:8080/panel'),
+        'http://localhost:4200',
+      ),
+    ).toMatchObject({ origin: 'http://127.0.0.1:8080' });
+    expect(() =>
+      parsePersistentPanelConfig(
+        { id: OPEN_PERSISTENT_PANEL_MESSAGE },
+        trustedNode('http://127.0.0.1:8080/panel'),
+        'https://portal.example.test',
+      ),
+    ).toThrow(/registered provider UI URL is invalid/i);
+  });
+
+  it('projects only bounded account and workspace fields and never credentials', () => {
+    const target = persistentPanelTarget(
+      {
+        organization: 'org-a',
+        token: 'must-not-leak',
+        portalContext: { crdGatewayApiUrl: 'must-not-leak' },
+      },
+      {
+        portalContext: {},
+        entityId: 'parent/default',
+        accountId: 'team-a',
+        userId: 'must-not-leak',
+        userEmail: 'must-not-leak',
+        token: 'must-not-leak',
+        portalBaseUrl: 'must-not-leak',
+        accountPath: 'root:orgs:org-a:team-a',
+        kcpPath: 'root:orgs:org-a:team-a',
+        namespaceId: 'apps',
+        entityName: 'example',
+        entityKind: 'Database',
+        resourceDefinition: {
+          group: 'database.example.io',
+          version: 'v1alpha1',
+          kind: 'Database',
+        },
+      },
+    );
+
+    expect(target).toEqual({
+      organization: 'org-a',
+      account: 'team-a',
+      accountPath: 'root:orgs:org-a:team-a',
+      workspacePath: 'root:orgs:org-a:team-a',
+      namespace: 'apps',
+      resource: {
+        group: 'database.example.io',
+        version: 'v1alpha1',
+        kind: 'Database',
+        name: 'example',
+      },
+    });
+    expect(JSON.stringify(target)).not.toMatch(
+      /must-not-leak|token|gateway|email/i,
+    );
+  });
+
+  it('projects the observed Portal account and organization shapes', () => {
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        organizationId: 'parent/showroom',
+        accountId: 'ig-1',
+        entityId: 'parent/default',
+      }),
+    ).toEqual({
+      organization: 'showroom',
+      organizationId: 'parent/showroom',
+      account: 'ig-1',
+      workspacePath: 'root:orgs:showroom:ig-1',
+    });
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        organizationId: 'parent/showroom',
+        kcpPath: 'root:orgs:showroom',
+      }),
+    ).toEqual({
+      organization: 'showroom',
+      organizationId: 'parent/showroom',
+    });
+  });
+
+  it('uses bounded account fields in canonical precedence order', () => {
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        entityContext: { account: { id: 'from-entity-context' } },
+        accountId: 'from-account-id',
+        'core_platform-mesh_io_accountId': 'from-core-account-id',
+        accountPath: 'root:orgs:showroom:from-path',
+      }),
+    ).toMatchObject({ account: 'from-entity-context' });
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        accountId: 'from-account-id',
+        'core_platform-mesh_io_accountId': 'from-core-account-id',
+        accountPath: 'root:orgs:showroom:from-path',
+      }),
+    ).toMatchObject({ account: 'from-account-id' });
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        'core_platform-mesh_io_accountId': 'from-core-account-id',
+        accountPath: 'root:orgs:showroom:from-path',
+      }),
+    ).toMatchObject({ account: 'from-core-account-id' });
+  });
+
+  it('uses a valid matching account path only as the final account fallback', () => {
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        accountPath: 'root:orgs:showroom:ig-1',
+      }),
+    ).toMatchObject({ account: 'ig-1' });
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        accountPath: 'root:orgs:another-org:ig-1',
+      }),
+    ).not.toHaveProperty('account');
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        accountPath: 'ig-1',
+      }),
+    ).toMatchObject({
+      account: 'ig-1',
+      accountPath: 'ig-1',
+      workspacePath: 'root:orgs:showroom:ig-1',
+    });
+  });
+
+  it('uses the Account entity shape as a bounded fallback', () => {
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        entityKind: 'Account',
+        entityName: 'ig-1',
+      }),
+    ).toMatchObject({
+      account: 'ig-1',
+      workspacePath: 'root:orgs:showroom:ig-1',
+    });
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        entityKind: 'Namespace',
+        entityName: 'default',
+      }),
+    ).not.toHaveProperty('account');
+  });
+
+  it('rejects invalid workspace segments and overlong values', () => {
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        accountId: 'not/a/workspace',
+      }),
+    ).not.toHaveProperty('workspacePath');
+    expect(
+      persistentPanelTarget({
+        organization: 'x'.repeat(254),
+        accountId: 'team-a',
+      }),
+    ).not.toHaveProperty('organization');
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        accountId: 'team-a',
+        workspacePath: 'root:orgs:another-org:team-a',
+      }),
+    ).toMatchObject({
+      workspacePath: 'root:orgs:showroom:team-a',
+    });
+    expect(
+      persistentPanelTarget({
+        organization: 'showroom',
+        accountId: 'team-a',
+        kcpPath: 'root:orgs:showroom:team-b',
+      }),
+    ).toMatchObject({
+      workspacePath: 'root:orgs:showroom:team-a',
+    });
+  });
+
+  it('keeps the tracked navigation target when provider metadata is sparse', () => {
+    expect(
+      mergePersistentPanelTargets(
+        {
+          organization: 'org-a',
+          account: 'team-a',
+          namespace: 'apps',
+          resource: { kind: 'Database', name: 'old' },
+        },
+        { organization: 'org-a' },
+      ),
+    ).toEqual({
+      organization: 'org-a',
+      account: 'team-a',
+      namespace: 'apps',
+      resource: { kind: 'Database', name: 'old' },
+    });
+  });
+
+  it('drops deeper tracked scope when provider identity changes', () => {
+    expect(
+      mergePersistentPanelTargets(
+        { organization: 'org-a', account: 'team-a', namespace: 'apps' },
+        { organization: 'org-a', account: 'team-b' },
+      ),
+    ).toEqual({ organization: 'org-a', account: 'team-b' });
+    expect(
+      mergePersistentPanelTargets(
+        {
+          organization: 'org-a',
+          account: 'team-a',
+          namespace: 'apps',
+          resource: { kind: 'Database', name: 'old' },
+        },
+        { organization: 'org-b' },
+      ),
+    ).toEqual({ organization: 'org-b' });
+  });
+});

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.types.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.types.ts
@@ -1,0 +1,307 @@
+import type { NodeContext } from '@openmfp/portal-ui-lib';
+
+export const OPEN_PERSISTENT_PANEL_MESSAGE = 'portal.open-provider-panel';
+
+export const PROVIDER_PANEL_MESSAGE = {
+  close: 'portal.provider-panel.close',
+  closeFailed: 'portal.provider-panel.close-failed',
+  closed: 'portal.provider-panel.closed',
+  context: 'portal.provider-panel.context',
+  ready: 'portal.provider-panel.ready',
+  requestClose: 'portal.provider-panel.request-close',
+} as const;
+
+export interface PersistentPanelConfig {
+  id: string;
+  title: string;
+  url: string;
+  origin: string;
+}
+
+export interface PersistentPanelTarget {
+  organization?: string;
+  organizationId?: string;
+  account?: string;
+  accountPath?: string;
+  workspacePath?: string;
+  namespace?: string;
+  resource?: {
+    group?: string;
+    version?: string;
+    kind?: string;
+    name?: string;
+  };
+}
+
+export interface RegisteredProviderNode {
+  viewUrl?: string;
+  context?: Partial<NodeContext> & {
+    persistentPanel?: unknown;
+  };
+}
+
+export function mergePersistentPanelTargets(
+  current: PersistentPanelTarget,
+  update: PersistentPanelTarget,
+): PersistentPanelTarget {
+  const organizationChanged =
+    current.organization !== undefined &&
+    update.organization !== undefined &&
+    current.organization !== update.organization;
+  const accountChanged =
+    current.account !== undefined &&
+    update.account !== undefined &&
+    current.account !== update.account;
+
+  if (organizationChanged || accountChanged) {
+    return structuredClone(update);
+  }
+
+  // Provider nodes normally contain only panel capability metadata. Keep the
+  // target tracked by navigation and overlay any bounded scope that the
+  // requesting node does carry.
+  return structuredClone({ ...current, ...update });
+}
+
+interface OpenPanelMessage extends Record<string, unknown> {
+  id: string;
+}
+
+const panelIdPattern = /^[a-z0-9](?:[a-z0-9.-]{0,62}[a-z0-9])?$/;
+const workspaceSegmentPattern = /^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$/;
+
+export function parsePersistentPanelConfig(
+  message: OpenPanelMessage,
+  providerNode: RegisteredProviderNode | undefined,
+  portalOrigin: string,
+): PersistentPanelConfig {
+  if (message.id !== OPEN_PERSISTENT_PANEL_MESSAGE) {
+    throw new Error('Persistent panel request is invalid');
+  }
+
+  const capability = recordValue(providerNode?.context?.persistentPanel);
+  const id = boundedString(capability['id'], 64);
+  const title = boundedString(capability['title'], 80);
+  if (!id || !panelIdPattern.test(id)) {
+    throw new Error('Registered persistent panel id is invalid');
+  }
+  if (!title) {
+    throw new Error('Registered persistent panel title is invalid');
+  }
+
+  const registeredViewUrl = boundedString(providerNode?.viewUrl, 2048);
+  if (!registeredViewUrl) {
+    throw new Error('Registered provider UI URL is missing');
+  }
+
+  const portalURL = new URL(portalOrigin);
+  const url = new URL(registeredViewUrl, portalURL);
+  if (
+    url.origin === portalURL.origin ||
+    !allowedPanelURL(url, portalURL) ||
+    url.username ||
+    url.password
+  ) {
+    throw new Error('Registered provider UI URL is invalid');
+  }
+
+  return { id, title, url: url.toString(), origin: url.origin };
+}
+
+function allowedPanelURL(url: URL, portalURL: URL): boolean {
+  if (url.protocol === 'https:') {
+    return true;
+  }
+  return (
+    portalURL.protocol === 'http:' &&
+    url.protocol === 'http:' &&
+    ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)
+  );
+}
+
+export function persistentPanelTarget(
+  globalContext: Record<string, unknown>,
+  nodeContext?: NodeContext | Record<string, unknown>,
+): PersistentPanelTarget {
+  const context = { ...globalContext, ...(nodeContext ?? {}) };
+  const entityContext = recordValue(context['entityContext']);
+  const accountContext = recordValue(entityContext['account']);
+  const resourceDefinition = recordValue(context['resourceDefinition']);
+
+  const organization = boundedString(context['organization'], 253);
+  const organizationId = boundedString(context['organizationId'], 512);
+  const rawAccountPath = boundedString(context['accountPath'], 1024);
+  const account =
+    boundedString(accountContext['id'], 253) ||
+    boundedString(context['accountId'], 253) ||
+    boundedString(context['core_platform-mesh_io_accountId'], 253) ||
+    accountFromPath(rawAccountPath, organization) ||
+    accountFromEntity(context);
+
+  // Organization-only scope is valid, but descendants without an account are
+  // not. Organization context can carry a kcpPath, so fail closed before
+  // projecting workspace fields.
+  if (!account) {
+    return compact({ organization, organizationId });
+  }
+
+  const accountPath = validatedAccountPath(
+    rawAccountPath,
+    organization,
+    account,
+  );
+
+  const workspacePath =
+    validatedWorkspacePath(context['workspacePath'], organization, account) ||
+    validatedWorkspacePath(context['kcpPath'], organization, account) ||
+    validatedWorkspacePath(rawAccountPath, organization, account) ||
+    canonicalAccountPath(organization, account);
+  const namespace =
+    boundedString(context['namespaceId'], 253) ||
+    boundedString(resourceDefinition['namespace'], 253);
+  const resource = compact({
+    group:
+      boundedString(resourceDefinition['group'], 253) ||
+      boundedString(resourceDefinition['apiGroup'], 253),
+    version: boundedString(resourceDefinition['version'], 63),
+    kind:
+      boundedString(resourceDefinition['kind'], 253) ||
+      boundedString(context['entityKind'], 253),
+    name: boundedString(context['entityName'], 253),
+  });
+
+  return compact({
+    organization,
+    organizationId,
+    account,
+    accountPath,
+    workspacePath,
+    namespace,
+    resource: Object.keys(resource).length > 0 ? resource : undefined,
+  });
+}
+
+function accountFromPath(
+  accountPath: string | undefined,
+  organization: string | undefined,
+): string | undefined {
+  if (!accountPath) {
+    return undefined;
+  }
+  if (workspaceSegmentPattern.test(accountPath)) {
+    return accountPath;
+  }
+  const segments = accountPath.split(':');
+  if (
+    segments.length < 4 ||
+    segments[0] !== 'root' ||
+    segments[1] !== 'orgs' ||
+    segments.some((segment) => !workspaceSegmentPattern.test(segment)) ||
+    (organization !== undefined && segments[2] !== organization)
+  ) {
+    return undefined;
+  }
+  return boundedString(segments.at(-1), 253);
+}
+
+function accountFromEntity(
+  context: Record<string, unknown>,
+): string | undefined {
+  if (boundedString(context['entityKind'], 253) !== 'Account') {
+    return undefined;
+  }
+  return boundedString(context['entityName'], 253);
+}
+
+function canonicalWorkspacePath(
+  accountPath: string | undefined,
+): string | undefined {
+  if (!accountPath?.startsWith('root:')) {
+    return undefined;
+  }
+  const segments = accountPath.split(':');
+  if (
+    segments.length < 3 ||
+    segments.some((segment) => !workspaceSegmentPattern.test(segment))
+  ) {
+    return undefined;
+  }
+  return accountPath;
+}
+
+function validatedWorkspacePath(
+  value: unknown,
+  organization: string | undefined,
+  account: string | undefined,
+): string | undefined {
+  if (!organization || !account) {
+    return undefined;
+  }
+  const path = canonicalWorkspacePath(boundedString(value, 1024));
+  const segments = path?.split(':');
+  if (
+    !segments ||
+    segments.length < 4 ||
+    segments[0] !== 'root' ||
+    segments[1] !== 'orgs' ||
+    segments[2] !== organization ||
+    segments.at(-1) !== account
+  ) {
+    return undefined;
+  }
+  return path;
+}
+
+function validatedAccountPath(
+  value: string | undefined,
+  organization: string | undefined,
+  account: string,
+): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  if (workspaceSegmentPattern.test(value)) {
+    return value === account ? value : undefined;
+  }
+  return validatedWorkspacePath(value, organization, account);
+}
+
+function canonicalAccountPath(
+  organization: string | undefined,
+  account: string | undefined,
+): string | undefined {
+  if (
+    !organization ||
+    !account ||
+    !workspaceSegmentPattern.test(organization) ||
+    !workspaceSegmentPattern.test(account)
+  ) {
+    return undefined;
+  }
+  return `root:orgs:${organization}:${account}`;
+}
+
+function compact<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, item]) => item !== undefined),
+  ) as T;
+}
+
+function boundedString(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > maxLength || trimmed.includes('\u0000')) {
+    return undefined;
+  }
+  return trimmed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  return isRecord(value) ? value : {};
+}

--- a/projects/lib/portal-options/public-api.ts
+++ b/projects/lib/portal-options/public-api.ts
@@ -6,3 +6,4 @@ export * from './services/node-change-hook-config.service';
 export * from './services/node-context-processing.service';
 export * from './services/router-config.service';
 export * from './services/user-profile-config.service';
+export * from './persistent-panel/open-persistent-panel.listener';

--- a/projects/lib/portal-options/services/node-change-hook-config.service.spec.ts
+++ b/projects/lib/portal-options/services/node-change-hook-config.service.spec.ts
@@ -1,3 +1,4 @@
+import { PersistentPanelService } from '../persistent-panel/persistent-panel.service';
 import { CrdGatewayKcpPatchResolver } from './crd-gateway-kcp-patch-resolver.service';
 import { NodeChangeHookConfigServiceImpl } from './node-change-hook-config.service';
 import { TestBed } from '@angular/core/testing';
@@ -8,6 +9,10 @@ describe('NodeChangeHookConfigServiceImpl', () => {
   let service: NodeChangeHookConfigServiceImpl;
   let mockLuigiCoreService: any;
   let mockCrdGatewayKcpPatchResolver: MockedObject<CrdGatewayKcpPatchResolver>;
+  let mockPersistentPanelService: Pick<
+    PersistentPanelService,
+    'currentTarget' | 'updateTarget'
+  >;
 
   beforeEach(() => {
     mockLuigiCoreService = {
@@ -20,6 +25,10 @@ describe('NodeChangeHookConfigServiceImpl', () => {
     mockCrdGatewayKcpPatchResolver = {
       resolveCrdGatewayKcpPath: vi.fn(),
     } as unknown as MockedObject<CrdGatewayKcpPatchResolver>;
+    mockPersistentPanelService = {
+      currentTarget: vi.fn().mockReturnValue({}),
+      updateTarget: vi.fn(),
+    };
 
     TestBed.configureTestingModule({
       providers: [
@@ -28,6 +37,10 @@ describe('NodeChangeHookConfigServiceImpl', () => {
         {
           provide: CrdGatewayKcpPatchResolver,
           useValue: mockCrdGatewayKcpPatchResolver,
+        },
+        {
+          provide: PersistentPanelService,
+          useValue: mockPersistentPanelService,
         },
       ],
     });
@@ -53,9 +66,84 @@ describe('NodeChangeHookConfigServiceImpl', () => {
     ).toHaveBeenCalledWith(nextNode);
   });
 
+  describe('persistent provider panel context', () => {
+    it('clears stale account scope when navigation returns to the organization', async () => {
+      mockPersistentPanelService.currentTarget = vi.fn().mockReturnValue({
+        organization: 'showroom',
+        account: 'ig-1',
+        workspacePath: 'root:orgs:showroom:ig-1',
+      });
+
+      await service.nodeChangeHook(
+        { context: { accountId: 'ig-1' } } as any,
+        { context: { organization: 'showroom' } } as any,
+        { organization: 'showroom' } as any,
+      );
+
+      expect(mockPersistentPanelService.updateTarget).toHaveBeenCalledWith({
+        organization: 'showroom',
+      });
+    });
+
+    it('publishes the effective account, namespace, and resource scope', async () => {
+      await service.nodeChangeHook(
+        {} as any,
+        { context: { navigationContext: 'resource-details' } } as any,
+        {
+          organization: 'showroom',
+          accountId: 'ig-1',
+          kcpPath: 'root:orgs:showroom:ig-1',
+          namespaceId: 'apps',
+          entityKind: 'Database',
+          entityName: 'sample',
+        } as any,
+      );
+
+      expect(mockPersistentPanelService.updateTarget).toHaveBeenCalledWith({
+        organization: 'showroom',
+        account: 'ig-1',
+        workspacePath: 'root:orgs:showroom:ig-1',
+        namespace: 'apps',
+        resource: { kind: 'Database', name: 'sample' },
+      });
+    });
+
+    it('ignores a stale target from an earlier navigation that resolves last', async () => {
+      let resolveFirstNavigation!: () => void;
+      const firstNavigation = new Promise<void>((resolve) => {
+        resolveFirstNavigation = resolve;
+      });
+      mockCrdGatewayKcpPatchResolver.resolveCrdGatewayKcpPath
+        .mockReturnValueOnce(firstNavigation as any)
+        .mockResolvedValueOnce({} as any);
+
+      const staleUpdate = service.nodeChangeHook(
+        {} as any,
+        { context: { accountId: 'account-a' } } as any,
+        { organization: 'showroom' } as any,
+      );
+      await service.nodeChangeHook(
+        {} as any,
+        { context: { accountId: 'account-b' } } as any,
+        { organization: 'showroom' } as any,
+      );
+      resolveFirstNavigation();
+      await staleUpdate;
+
+      expect(mockPersistentPanelService.updateTarget).toHaveBeenCalledTimes(1);
+      expect(mockPersistentPanelService.updateTarget).toHaveBeenCalledWith({
+        organization: 'showroom',
+        account: 'account-b',
+        workspacePath: 'root:orgs:showroom:account-b',
+      });
+    });
+  });
+
   describe('accumulatePortalPermissions', () => {
     it('uses prevNode.context.portalPermissions as base when it exists', async () => {
-      const prevNode = { context: { portalPermissions: { pods: ['get'] } } } as any;
+      const prevNode = {
+        context: { portalPermissions: { pods: ['get'] } },
+      } as any;
       const nextNode = { context: {} } as any;
       const currentContext = {} as any;
 
@@ -67,11 +155,15 @@ describe('NodeChangeHookConfigServiceImpl', () => {
     it('falls back to currentContext.portalPermissions when prevNode has no portalPermissions', async () => {
       const prevNode = { context: {} } as any;
       const nextNode = { context: {} } as any;
-      const currentContext = { portalPermissions: { namespaces: ['list'] } } as any;
+      const currentContext = {
+        portalPermissions: { namespaces: ['list'] },
+      } as any;
 
       await service.nodeChangeHook(prevNode, nextNode, currentContext);
 
-      expect(currentContext.portalPermissions).toEqual({ namespaces: ['list'] });
+      expect(currentContext.portalPermissions).toEqual({
+        namespaces: ['list'],
+      });
     });
 
     it('falls back to empty object when both prevNode and currentContext have no portalPermissions', async () => {
@@ -115,7 +207,9 @@ describe('NodeChangeHookConfigServiceImpl', () => {
     });
 
     it('sets currentContext.portalPermissions with the merged result', async () => {
-      const prevNode = { context: { portalPermissions: { secrets: ['get'] } } } as any;
+      const prevNode = {
+        context: { portalPermissions: { secrets: ['get'] } },
+      } as any;
       const nextNode = {
         context: {
           nodesPermissions: [{ resource: 'pods', actions: ['list'] }],
@@ -148,7 +242,9 @@ describe('NodeChangeHookConfigServiceImpl', () => {
     });
 
     it('overrides an existing resource entry with new actions from nodesPermissions', async () => {
-      const prevNode = { context: { portalPermissions: { pods: ['get'] } } } as any;
+      const prevNode = {
+        context: { portalPermissions: { pods: ['get'] } },
+      } as any;
       const nextNode = {
         context: {
           nodesPermissions: [

--- a/projects/lib/portal-options/services/node-change-hook-config.service.spec.ts
+++ b/projects/lib/portal-options/services/node-change-hook-config.service.spec.ts
@@ -9,9 +9,10 @@ describe('NodeChangeHookConfigServiceImpl', () => {
   let service: NodeChangeHookConfigServiceImpl;
   let mockLuigiCoreService: any;
   let mockCrdGatewayKcpPatchResolver: MockedObject<CrdGatewayKcpPatchResolver>;
+  let completeTargetUpdate: ReturnType<typeof vi.fn>;
   let mockPersistentPanelService: Pick<
     PersistentPanelService,
-    'currentTarget' | 'updateTarget'
+    'beginTargetUpdate'
   >;
 
   beforeEach(() => {
@@ -19,15 +20,14 @@ describe('NodeChangeHookConfigServiceImpl', () => {
       navigation: vi.fn().mockReturnValue({
         navigate: vi.fn(),
       }),
-      getGlobalContext: vi.fn().mockReturnValue({ organization: 'org1' }),
     };
 
     mockCrdGatewayKcpPatchResolver = {
       resolveCrdGatewayKcpPath: vi.fn(),
     } as unknown as MockedObject<CrdGatewayKcpPatchResolver>;
+    completeTargetUpdate = vi.fn();
     mockPersistentPanelService = {
-      currentTarget: vi.fn().mockReturnValue({}),
-      updateTarget: vi.fn(),
+      beginTargetUpdate: vi.fn().mockReturnValue(completeTargetUpdate),
     };
 
     TestBed.configureTestingModule({
@@ -68,20 +68,15 @@ describe('NodeChangeHookConfigServiceImpl', () => {
 
   describe('persistent provider panel context', () => {
     it('clears stale account scope when navigation returns to the organization', async () => {
-      mockPersistentPanelService.currentTarget = vi.fn().mockReturnValue({
-        organization: 'showroom',
-        account: 'ig-1',
-        workspacePath: 'root:orgs:showroom:ig-1',
-      });
-
       await service.nodeChangeHook(
         { context: { accountId: 'ig-1' } } as any,
         { context: { organization: 'showroom' } } as any,
         { organization: 'showroom' } as any,
       );
 
-      expect(mockPersistentPanelService.updateTarget).toHaveBeenCalledWith({
+      expect(completeTargetUpdate).toHaveBeenCalledWith({
         organization: 'showroom',
+        portalPermissions: {},
       });
     });
 
@@ -99,20 +94,28 @@ describe('NodeChangeHookConfigServiceImpl', () => {
         } as any,
       );
 
-      expect(mockPersistentPanelService.updateTarget).toHaveBeenCalledWith({
+      expect(completeTargetUpdate).toHaveBeenCalledWith({
         organization: 'showroom',
-        account: 'ig-1',
-        workspacePath: 'root:orgs:showroom:ig-1',
-        namespace: 'apps',
-        resource: { kind: 'Database', name: 'sample' },
+        accountId: 'ig-1',
+        kcpPath: 'root:orgs:showroom:ig-1',
+        namespaceId: 'apps',
+        entityKind: 'Database',
+        entityName: 'sample',
+        navigationContext: 'resource-details',
+        portalPermissions: {},
       });
     });
 
-    it('ignores a stale target from an earlier navigation that resolves last', async () => {
+    it('starts updates in navigation order and completes them after KCP resolution', async () => {
       let resolveFirstNavigation!: () => void;
       const firstNavigation = new Promise<void>((resolve) => {
         resolveFirstNavigation = resolve;
       });
+      const completeFirstTargetUpdate = vi.fn();
+      const completeSecondTargetUpdate = vi.fn();
+      vi.mocked(mockPersistentPanelService.beginTargetUpdate)
+        .mockReturnValueOnce(completeFirstTargetUpdate)
+        .mockReturnValueOnce(completeSecondTargetUpdate);
       mockCrdGatewayKcpPatchResolver.resolveCrdGatewayKcpPath
         .mockReturnValueOnce(firstNavigation as any)
         .mockResolvedValueOnce({} as any);
@@ -122,19 +125,58 @@ describe('NodeChangeHookConfigServiceImpl', () => {
         { context: { accountId: 'account-a' } } as any,
         { organization: 'showroom' } as any,
       );
+
+      expect(completeFirstTargetUpdate).not.toHaveBeenCalled();
+
       await service.nodeChangeHook(
         {} as any,
         { context: { accountId: 'account-b' } } as any,
         { organization: 'showroom' } as any,
       );
+
+      expect(completeSecondTargetUpdate).toHaveBeenCalledWith({
+        organization: 'showroom',
+        accountId: 'account-b',
+        portalPermissions: {},
+      });
+
       resolveFirstNavigation();
       await staleUpdate;
 
-      expect(mockPersistentPanelService.updateTarget).toHaveBeenCalledTimes(1);
-      expect(mockPersistentPanelService.updateTarget).toHaveBeenCalledWith({
+      expect(completeFirstTargetUpdate).toHaveBeenCalledWith({
         organization: 'showroom',
-        account: 'account-b',
-        workspacePath: 'root:orgs:showroom:account-b',
+        accountId: 'account-a',
+        portalPermissions: {},
+      });
+    });
+
+    it('publishes the resolver-enriched path for a nested account', async () => {
+      mockCrdGatewayKcpPatchResolver.resolveCrdGatewayKcpPath.mockImplementation(
+        async (nextNode) => {
+          nextNode.context.kcpPath = 'root:orgs:showroom:parent:child';
+          nextNode.context.accountPath = 'parent:child';
+          return {
+            kcpPath: nextNode.context.kcpPath,
+            accountPath: nextNode.context.accountPath,
+          };
+        },
+      );
+
+      await service.nodeChangeHook(
+        {} as any,
+        { context: { accountId: 'child' } } as any,
+        {
+          organization: 'showroom',
+          kcpPath: 'root:orgs:showroom:parent',
+        } as any,
+      );
+
+      expect(completeTargetUpdate).toHaveBeenCalledWith({
+        organization: 'showroom',
+        accountId: 'child',
+        accountPath: 'parent:child',
+        kcpPath: 'root:orgs:showroom:parent:child',
+        portalPermissions: {},
       });
     });
   });

--- a/projects/lib/portal-options/services/node-change-hook-config.service.ts
+++ b/projects/lib/portal-options/services/node-change-hook-config.service.ts
@@ -1,6 +1,5 @@
 import { PortalLuigiNode } from '../models/luigi-node';
 import { PersistentPanelService } from '../persistent-panel/persistent-panel.service';
-import { persistentPanelTarget } from '../persistent-panel/persistent-panel.types';
 import { CrdGatewayKcpPatchResolver } from './crd-gateway-kcp-patch-resolver.service';
 import { Injectable, inject } from '@angular/core';
 import {
@@ -14,14 +13,14 @@ export class NodeChangeHookConfigServiceImpl implements NodeChangeHookConfigServ
   private luigiCoreService = inject(LuigiCoreService);
   private crdGatewayKcpPatchResolver = inject(CrdGatewayKcpPatchResolver);
   private persistentPanelService = inject(PersistentPanelService);
-  private navigationSequence = 0;
 
   async nodeChangeHook(
     prevNode: PortalLuigiNode,
     nextNode: PortalLuigiNode,
     currentContext: NodeContext,
   ) {
-    const navigationSequence = ++this.navigationSequence;
+    const updatePersistentPanelTarget =
+      this.persistentPanelService.beginTargetUpdate();
 
     if (
       nextNode.initialRoute &&
@@ -33,15 +32,10 @@ export class NodeChangeHookConfigServiceImpl implements NodeChangeHookConfigServ
 
     this.accumulatePortalPermissions(prevNode, nextNode, currentContext);
     await this.crdGatewayKcpPatchResolver.resolveCrdGatewayKcpPath(nextNode);
-    if (navigationSequence !== this.navigationSequence) {
-      return;
-    }
-    this.persistentPanelService.updateTarget(
-      persistentPanelTarget(this.luigiCoreService.getGlobalContext(), {
-        ...currentContext,
-        ...(nextNode.context ?? {}),
-      }),
-    );
+    updatePersistentPanelTarget({
+      ...currentContext,
+      ...(nextNode.context ?? {}),
+    });
   }
 
   private accumulatePortalPermissions(

--- a/projects/lib/portal-options/services/node-change-hook-config.service.ts
+++ b/projects/lib/portal-options/services/node-change-hook-config.service.ts
@@ -1,4 +1,6 @@
 import { PortalLuigiNode } from '../models/luigi-node';
+import { PersistentPanelService } from '../persistent-panel/persistent-panel.service';
+import { persistentPanelTarget } from '../persistent-panel/persistent-panel.types';
 import { CrdGatewayKcpPatchResolver } from './crd-gateway-kcp-patch-resolver.service';
 import { Injectable, inject } from '@angular/core';
 import {
@@ -11,12 +13,16 @@ import {
 export class NodeChangeHookConfigServiceImpl implements NodeChangeHookConfigService {
   private luigiCoreService = inject(LuigiCoreService);
   private crdGatewayKcpPatchResolver = inject(CrdGatewayKcpPatchResolver);
+  private persistentPanelService = inject(PersistentPanelService);
+  private navigationSequence = 0;
 
   async nodeChangeHook(
     prevNode: PortalLuigiNode,
     nextNode: PortalLuigiNode,
     currentContext: NodeContext,
   ) {
+    const navigationSequence = ++this.navigationSequence;
+
     if (
       nextNode.initialRoute &&
       nextNode.virtualTree &&
@@ -27,6 +33,15 @@ export class NodeChangeHookConfigServiceImpl implements NodeChangeHookConfigServ
 
     this.accumulatePortalPermissions(prevNode, nextNode, currentContext);
     await this.crdGatewayKcpPatchResolver.resolveCrdGatewayKcpPath(nextNode);
+    if (navigationSequence !== this.navigationSequence) {
+      return;
+    }
+    this.persistentPanelService.updateTarget(
+      persistentPanelTarget(this.luigiCoreService.getGlobalContext(), {
+        ...currentContext,
+        ...(nextNode.context ?? {}),
+      }),
+    );
   }
 
   private accumulatePortalPermissions(


### PR DESCRIPTION
## Summary

- add a reusable persistent provider-panel listener and floating panel shell
- keep bounded organization, account, namespace, and resource context synchronized across navigation
- require a registered cross-origin provider UI with exact-origin messaging and acknowledged cleanup

## Verification

- `npm test`
- `npm run build`

Refs platform-mesh/backlog#344