### PR TITLE
feat(portal-options): Resize persistent panels

### DIFF
--- a/projects/lib/portal-options/persistent-panel/persistent-panel.html
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.html
@@ -14,7 +14,7 @@
     aria-label="Resize provider panel"
     aria-orientation="vertical"
     aria-controls="persistent-panel-content"
-    [attr.aria-valuemin]="minPanelWidth"
+    [attr.aria-valuemin]="minPanelWidth()"
     [attr.aria-valuemax]="maxPanelWidth()"
     [attr.aria-valuenow]="panelWidth()"
     tabindex="0"

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.html
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.html
@@ -1,5 +1,5 @@
 <section
-  class="persistent-panel"
+  class="persistent-panel fd-dialog__content"
   role="complementary"
   aria-labelledby="persistent-panel-title"
   [attr.aria-hidden]="state() === 'hidden'"
@@ -25,60 +25,84 @@
     (lostpointercapture)="finishResize($event)"
     (keydown)="resizeWithKeyboard($event)"
   ></div>
-  <header class="persistent-panel-header">
-    <div>
-      <h2 id="persistent-panel-title">{{ title() }}</h2>
-      @if (closeError()) {
-      <p role="alert">{{ closeError() }}</p>
-      }
+  <header
+    class="persistent-panel-header fd-dialog__header fd-bar fd-bar--header"
+  >
+    <div class="fd-bar__left persistent-panel-title-area">
+      <div class="fd-bar__element persistent-panel-title-element">
+        <h2
+          id="persistent-panel-title"
+          class="fd-title fd-title--h5 persistent-panel-title"
+        >
+          {{ title() }}
+        </h2>
+      </div>
     </div>
-    <div class="persistent-panel-actions">
-      <button
-        aria-label="Toggle panel size"
-        [attr.aria-pressed]="state() === 'maximized'"
-        title="Toggle panel size"
-        type="button"
-        (click)="toggleSize()"
-      >
-        @if (state() === 'maximized') { ◲ } @else { ◱ }
-      </button>
-      <button
-        aria-label="Collapse panel"
-        title="Collapse panel"
-        type="button"
-        (click)="collapse()"
-      >
-        —
-      </button>
-      <button
-        aria-label="Close panel"
-        title="Close panel"
-        type="button"
-        (click)="close()"
-      >
-        ×
-      </button>
+    <div class="fd-bar__right persistent-panel-actions">
+      <div class="fd-bar__element">
+        <button
+          class="fd-button fd-button--transparent fd-button--compact"
+          aria-label="Toggle panel size"
+          [attr.aria-pressed]="state() === 'maximized'"
+          title="Toggle panel size"
+          type="button"
+          (click)="toggleSize()"
+        >
+          <i
+            class="sap-icon"
+            [class.sap-icon--exitfullscreen]="state() === 'maximized'"
+            [class.sap-icon--full-screen]="state() !== 'maximized'"
+            aria-hidden="true"
+          ></i>
+        </button>
+      </div>
+      <div class="fd-bar__element">
+        <button
+          class="fd-button fd-button--transparent fd-button--compact"
+          aria-label="Collapse panel"
+          title="Collapse panel"
+          type="button"
+          (click)="collapse()"
+        >
+          <i class="sap-icon sap-icon--collapse" aria-hidden="true"></i>
+        </button>
+      </div>
+      <div class="fd-bar__element">
+        <button
+          class="fd-button fd-button--transparent fd-button--compact"
+          aria-label="Close panel"
+          title="Close panel"
+          type="button"
+          (click)="close()"
+        >
+          <i class="sap-icon sap-icon--decline" aria-hidden="true"></i>
+        </button>
+      </div>
     </div>
   </header>
-  @if (source()) {
-  <iframe
-    #panelFrame
-    id="persistent-panel-content"
-    class="persistent-panel-frame"
-    referrerpolicy="no-referrer"
-    sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
-    [src]="source()"
-    [title]="title()"
-    (load)="frameLoaded()"
-  ></iframe>
-  }
+  <div class="persistent-panel-body fd-dialog__body">
+    @if (closeError()) {
+    <p class="persistent-panel-error" role="alert">{{ closeError() }}</p>
+    } @if (source()) {
+    <iframe
+      #panelFrame
+      id="persistent-panel-content"
+      class="persistent-panel-frame"
+      referrerpolicy="no-referrer"
+      sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
+      [src]="source()"
+      [title]="title()"
+      (load)="frameLoaded()"
+    ></iframe>
+    }
+  </div>
 </section>
 
 @if (state() === 'hidden' && source() && !closing()) {
 <button
   #reopenButton
-  class="persistent-panel-reopen"
-  aria-label="Open provider panel"
+  class="persistent-panel-reopen fd-button fd-button--emphasized fd-button--compact"
+  [attr.aria-label]="'Open ' + title()"
   type="button"
   (click)="expand()"
 >

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.html
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.html
@@ -5,7 +5,26 @@
   [attr.aria-hidden]="state() === 'hidden'"
   [class.maximized]="state() === 'maximized'"
   [class.open]="state() !== 'hidden'"
+  [class.resizing]="resizing()"
+  [style.--pm-panel-width]="panelWidth() + 'px'"
 >
+  <div
+    class="persistent-panel-resizer"
+    role="separator"
+    aria-label="Resize provider panel"
+    aria-orientation="vertical"
+    aria-controls="persistent-panel-content"
+    [attr.aria-valuemin]="minPanelWidth"
+    [attr.aria-valuemax]="maxPanelWidth()"
+    [attr.aria-valuenow]="panelWidth()"
+    tabindex="0"
+    (pointerdown)="beginResize($event)"
+    (pointermove)="resize($event)"
+    (pointerup)="finishResize($event)"
+    (pointercancel)="finishResize($event)"
+    (lostpointercapture)="finishResize($event)"
+    (keydown)="resizeWithKeyboard($event)"
+  ></div>
   <header class="persistent-panel-header">
     <div>
       <h2 id="persistent-panel-title">{{ title() }}</h2>
@@ -44,6 +63,7 @@
   @if (source()) {
   <iframe
     #panelFrame
+    id="persistent-panel-content"
     class="persistent-panel-frame"
     referrerpolicy="no-referrer"
     sandbox="allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.scss
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.scss
@@ -32,11 +32,32 @@
   position: absolute;
   top: 0;
   bottom: 0;
-  left: -0.25rem;
+  left: -0.375rem;
   z-index: 1;
-  width: 0.5rem;
+  width: 0.75rem;
   cursor: col-resize;
   touch-action: none;
+}
+
+.persistent-panel-resizer::after {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0.125rem;
+  height: 3rem;
+  background: var(--sapContent_FocusColor, #0064d9);
+  border-radius: 0.125rem;
+  content: '';
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -50%);
+  transition: opacity 120ms ease-in-out;
+}
+
+.persistent-panel-resizer:hover::after,
+.persistent-panel-resizer:focus-visible::after,
+.persistent-panel.resizing .persistent-panel-resizer::after {
+  opacity: 0.65;
 }
 
 .persistent-panel-resizer:focus-visible {

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.scss
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.scss
@@ -23,11 +23,6 @@
   grid-template-rows: var(--pm-panel-header-height) 1fr;
 }
 
-.persistent-panel.maximized {
-  left: 4.25rem;
-  width: auto;
-}
-
 .persistent-panel-resizer {
   position: absolute;
   top: 0;

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.scss
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.scss
@@ -1,5 +1,4 @@
 :host {
-  --pm-panel-header-height: 3rem;
   font-family: var(--sapFontFamily, '72', Arial, sans-serif);
 }
 
@@ -11,16 +10,31 @@
   z-index: 1000;
   display: none;
   box-sizing: border-box;
+  min-width: 0;
+  max-width: none;
+  min-height: 0;
+  max-height: none;
   width: var(--pm-panel-width, min(34rem, 100vw));
-  background: var(--sapBackgroundColor, #fff);
-  border-left: 1px solid var(--sapGroup_ContentBorderColor, #d9d9d9);
-  box-shadow: -0.25rem 0 1rem rgb(0 0 0 / 12%);
-  clip-path: inset(0 0 0 -1.25rem);
+  background: var(--sapGroup_ContentBackground, #fff);
+  border-radius: var(--sapElement_BorderCornerRadius, 0.75rem) 0 0
+    var(--sapElement_BorderCornerRadius, 0.75rem);
+  box-shadow: var(
+    --sapContent_Shadow3,
+    0 0 0 0.0625rem rgb(34 53 72 / 48%),
+    0 1.25rem 5rem rgb(34 53 72 / 30%)
+  );
+}
+
+:host-context(.lui-breadcrumb) .persistent-panel {
+  top: calc(
+    var(--luigi__shellbar--height, 3.25rem) +
+      var(--luigi__breadcrumb--height, 2.75rem)
+  );
 }
 
 .persistent-panel.open {
   display: grid;
-  grid-template-rows: var(--pm-panel-header-height) 1fr;
+  grid-template-rows: auto minmax(0, 1fr);
 }
 
 .persistent-panel-resizer {
@@ -52,12 +66,17 @@
 .persistent-panel-resizer:hover::after,
 .persistent-panel-resizer:focus-visible::after,
 .persistent-panel.resizing .persistent-panel-resizer::after {
-  opacity: 0.65;
+  opacity: 1;
 }
 
 .persistent-panel-resizer:focus-visible {
-  outline: 0.125rem solid var(--sapContent_FocusColor, #0064d9);
-  outline-offset: -0.125rem;
+  outline: 0;
+}
+
+.persistent-panel-resizer:focus-visible::after {
+  outline: var(--sapContent_FocusWidth, 0.125rem) solid
+    var(--sapContent_FocusColor, #0032a5);
+  outline-offset: 0.125rem;
 }
 
 .persistent-panel.maximized .persistent-panel-resizer {
@@ -65,60 +84,45 @@
 }
 
 .persistent-panel-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 0.75rem 0 1rem;
-  color: var(--sapShell_TextColor, #1d2d3e);
-  background: var(--sapShell_Background, #fff);
-  border-bottom: 1px solid var(--sapGroup_ContentBorderColor, #d9d9d9);
+  min-width: 0;
+  border-radius: var(--sapElement_BorderCornerRadius, 0.75rem) 0 0;
 }
 
-.persistent-panel-header h2 {
+.persistent-panel-title-area,
+.persistent-panel-title-element {
+  min-width: 0;
+}
+
+.persistent-panel-title {
   overflow: hidden;
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.persistent-panel-header > div:first-child {
-  min-width: 0;
-}
-
-.persistent-panel-header p {
-  margin: 0;
-  color: var(--sapNegativeTextColor, #aa0808);
-  font-size: 0.75rem;
-}
-
-.persistent-panel-actions {
+.persistent-panel-body {
   display: flex;
-  flex: 0 0 auto;
-  gap: 0.25rem;
+  min-width: 0;
+  min-height: 0;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
 }
 
-.persistent-panel-actions button,
-.persistent-panel-reopen {
-  min-width: 2rem;
-  min-height: 2rem;
-  color: var(--sapButton_TextColor, #0064d9);
-  background: transparent;
-  border: 0;
-  border-radius: 0.25rem;
-  cursor: pointer;
-}
-
-.persistent-panel-actions button:hover,
-.persistent-panel-reopen:hover {
-  background: var(--sapButton_Lite_Hover_Background, #eaecee);
+.persistent-panel-error {
+  flex: none;
+  margin: 0;
+  padding: 0.5rem 1rem;
+  color: var(--sapNegativeTextColor, #aa0808);
+  background: var(--sapErrorBackground, #ffeaf4);
+  font-size: var(--sapFontSmallSize, 0.75rem);
 }
 
 .persistent-panel-frame {
+  min-height: 0;
+  flex: 1;
   width: 100%;
-  height: 100%;
   border: 0;
+  border-bottom-left-radius: var(--sapElement_BorderCornerRadius, 0.75rem);
 }
 
 .persistent-panel.resizing,
@@ -136,10 +140,10 @@
   right: 1rem;
   bottom: 1rem;
   z-index: 1000;
-  padding: 0.5rem 0.75rem;
-  color: var(--sapButton_Emphasized_TextColor, #fff);
-  background: var(--sapButton_Emphasized_Background, #0070f2);
-  box-shadow: 0 0.25rem 0.75rem rgb(0 0 0 / 20%);
+  overflow: hidden;
+  max-width: calc(100vw - 2rem);
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @media (max-width: 600px) {
@@ -147,9 +151,17 @@
   .persistent-panel.maximized {
     left: 0;
     width: 100vw;
+    border-radius: 0;
+    box-shadow: none;
   }
 
   .persistent-panel-resizer {
     display: none;
+  }
+
+  .persistent-panel-header,
+  .persistent-panel-body,
+  .persistent-panel-frame {
+    border-radius: 0;
   }
 }

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.scss
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.scss
@@ -10,10 +10,12 @@
   bottom: 0;
   z-index: 1000;
   display: none;
-  width: min(34rem, 100vw);
+  box-sizing: border-box;
+  width: var(--pm-panel-width, min(34rem, 100vw));
   background: var(--sapBackgroundColor, #fff);
   border-left: 1px solid var(--sapGroup_ContentBorderColor, #d9d9d9);
   box-shadow: -0.25rem 0 1rem rgb(0 0 0 / 12%);
+  clip-path: inset(0 0 0 -1.25rem);
 }
 
 .persistent-panel.open {
@@ -24,6 +26,26 @@
 .persistent-panel.maximized {
   left: 4.25rem;
   width: auto;
+}
+
+.persistent-panel-resizer {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -0.25rem;
+  z-index: 1;
+  width: 0.5rem;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.persistent-panel-resizer:focus-visible {
+  outline: 0.125rem solid var(--sapContent_FocusColor, #0064d9);
+  outline-offset: -0.125rem;
+}
+
+.persistent-panel.maximized .persistent-panel-resizer {
+  display: none;
 }
 
 .persistent-panel-header {
@@ -45,6 +67,10 @@
   white-space: nowrap;
 }
 
+.persistent-panel-header > div:first-child {
+  min-width: 0;
+}
+
 .persistent-panel-header p {
   margin: 0;
   color: var(--sapNegativeTextColor, #aa0808);
@@ -53,6 +79,7 @@
 
 .persistent-panel-actions {
   display: flex;
+  flex: 0 0 auto;
   gap: 0.25rem;
 }
 
@@ -78,6 +105,16 @@
   border: 0;
 }
 
+.persistent-panel.resizing,
+.persistent-panel.resizing .persistent-panel-resizer {
+  cursor: col-resize;
+}
+
+.persistent-panel.resizing .persistent-panel-frame {
+  pointer-events: none;
+  user-select: none;
+}
+
 .persistent-panel-reopen {
   position: fixed;
   right: 1rem;
@@ -94,5 +131,9 @@
   .persistent-panel.maximized {
     left: 0;
     width: 100vw;
+  }
+
+  .persistent-panel-resizer {
+    display: none;
   }
 }

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.service.spec.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.service.spec.ts
@@ -36,6 +36,49 @@ describe('PersistentPanelService', () => {
     });
   });
 
+  it('uses the Portal Fundamental styles and SAP icons for panel controls', async () => {
+    service.open(config, { organization: 'showroom' });
+    const panelHost = document.querySelector('pm-persistent-panel');
+    const header = panelHost?.querySelector('.persistent-panel-header');
+    const actions = panelHost?.querySelectorAll(
+      '.persistent-panel-actions .fd-button.fd-button--transparent.fd-button--compact',
+    );
+
+    expect(header?.classList).toContain('fd-dialog__header');
+    expect(header?.classList).toContain('fd-bar');
+    expect(header?.classList).toContain('fd-bar--header');
+    expect(panelHost?.querySelector('.fd-title.fd-title--h5')).not.toBeNull();
+    expect(actions).toHaveLength(3);
+    expect(
+      panelHost?.querySelector('.sap-icon.sap-icon--full-screen'),
+    ).not.toBeNull();
+    expect(
+      panelHost?.querySelector('.sap-icon.sap-icon--collapse'),
+    ).not.toBeNull();
+    expect(
+      panelHost?.querySelector('.sap-icon.sap-icon--decline'),
+    ).not.toBeNull();
+
+    const collapseButton = panelHost?.querySelector<HTMLButtonElement>(
+      '[aria-label="Collapse panel"]',
+    );
+    collapseButton?.click();
+
+    await vi.waitFor(() =>
+      expect(
+        panelHost?.querySelector<HTMLButtonElement>('.persistent-panel-reopen'),
+      ).not.toBeNull(),
+    );
+    const reopenButton = panelHost?.querySelector<HTMLButtonElement>(
+      '.persistent-panel-reopen',
+    );
+    expect(reopenButton?.classList).toContain('fd-button--emphasized');
+    expect(reopenButton?.classList).toContain('fd-button--compact');
+    expect(reopenButton?.getAttribute('aria-label')).toBe(
+      'Open Provider tools',
+    );
+  });
+
   it('tracks navigation before a panel is opened and clears state on destroy', () => {
     service.beginTargetUpdate()({
       organization: 'showroom',

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.spec.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.spec.ts
@@ -131,6 +131,19 @@ describe('PersistentPanelComponent', () => {
     component.ngOnDestroy();
   });
 
+  it('derives panel bounds from the Portal root font size', () => {
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+      fontSize: '20px',
+    } as CSSStyleDeclaration);
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200);
+    const component = createPanel();
+
+    expect(component.minPanelWidth).toBe(400);
+    expect(component.panelWidth()).toBe(680);
+    expect(component.maxPanelWidth()).toBe(1115);
+    component.ngOnDestroy();
+  });
+
   it('ignores unsupported resize input and releases lost pointer capture', () => {
     vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(200);
     const component = createPanel();

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.spec.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.spec.ts
@@ -14,6 +14,7 @@ const config = {
 describe('PersistentPanelComponent', () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it('posts context and lifecycle messages only to the registered origin', () => {
@@ -57,6 +58,110 @@ describe('PersistentPanelComponent', () => {
     component.toggleSize();
     expect(component.state()).toBe('expanded');
     expect(component.source()).not.toBeNull();
+    component.ngOnDestroy();
+  });
+
+  it('resizes with a pointer and clamps the panel to the supported bounds', () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200);
+    const component = createPanel();
+    const handle = resizeHandle();
+    component.open(config, {});
+
+    component.beginResize(pointerEvent(handle, 7, 656));
+    expect(handle.setPointerCapture).toHaveBeenCalledWith(7);
+    expect(component.resizing()).toBe(true);
+
+    component.resize(pointerEvent(handle, 7, 1199));
+    expect(component.panelWidth()).toBe(320);
+    component.resize(pointerEvent(handle, 7, 0));
+    expect(component.panelWidth()).toBe(1132);
+
+    component.finishResize(pointerEvent(handle, 7, 0));
+    expect(handle.releasePointerCapture).toHaveBeenCalledWith(7);
+    expect(component.resizing()).toBe(false);
+    expect(component.source()).not.toBeNull();
+    component.ngOnDestroy();
+  });
+
+  it('supports accessible keyboard resizing', () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200);
+    const component = createPanel();
+    const preventDefault = vi.fn();
+
+    component.resizeWithKeyboard({
+      key: 'ArrowLeft',
+      preventDefault,
+    } as unknown as KeyboardEvent);
+    expect(component.panelWidth()).toBe(576);
+
+    component.resizeWithKeyboard({
+      key: 'Home',
+      preventDefault,
+    } as unknown as KeyboardEvent);
+    expect(component.panelWidth()).toBe(320);
+
+    component.resizeWithKeyboard({
+      key: 'End',
+      preventDefault,
+    } as unknown as KeyboardEvent);
+    expect(component.panelWidth()).toBe(1132);
+    expect(preventDefault).toHaveBeenCalledTimes(3);
+    component.ngOnDestroy();
+  });
+
+  it('keeps the preferred width while clamping it to a resized viewport', () => {
+    let viewportWidth = 1200;
+    vi.spyOn(window, 'innerWidth', 'get').mockImplementation(
+      () => viewportWidth,
+    );
+    const component = createPanel();
+    component.resizeWithKeyboard({
+      key: 'End',
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent);
+    expect(component.panelWidth()).toBe(1132);
+
+    viewportWidth = 800;
+    window.dispatchEvent(new Event('resize'));
+    expect(component.panelWidth()).toBe(732);
+
+    viewportWidth = 1200;
+    window.dispatchEvent(new Event('resize'));
+    expect(component.panelWidth()).toBe(1132);
+    component.ngOnDestroy();
+  });
+
+  it('ignores unsupported resize input and releases lost pointer capture', () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(200);
+    const component = createPanel();
+    const handle = resizeHandle(false);
+
+    component.beginResize(pointerEvent(handle, 7, 0));
+    component.open(config, {});
+    component.beginResize(pointerEvent(handle, 7, 0, { button: 1 }));
+    component.beginResize(pointerEvent(handle, 7, 0, { isPrimary: false }));
+    expect(component.resizing()).toBe(false);
+    expect(component.maxPanelWidth()).toBe(320);
+
+    component.beginResize(pointerEvent(handle, 7, 0));
+    component.resize(pointerEvent(handle, 8, 0));
+    expect(component.panelWidth()).toBe(320);
+    component.finishResize(pointerEvent(handle, 8, 0));
+    expect(component.resizing()).toBe(true);
+    component.finishResize(pointerEvent(handle, 7, 0));
+    expect(handle.releasePointerCapture).not.toHaveBeenCalled();
+    component.finishResize(pointerEvent(handle, 7, 0));
+
+    const preventDefault = vi.fn();
+    component.resizeWithKeyboard({
+      key: 'ArrowRight',
+      preventDefault,
+    } as unknown as KeyboardEvent);
+    component.resizeWithKeyboard({
+      key: 'PageDown',
+      preventDefault,
+    } as unknown as KeyboardEvent);
+    expect(preventDefault).toHaveBeenCalledTimes(1);
     component.ngOnDestroy();
   });
 
@@ -326,4 +431,29 @@ function frameWith(postMessage: ReturnType<typeof vi.fn>) {
 
 function nextMicrotask(): Promise<void> {
   return new Promise((resolve) => queueMicrotask(resolve));
+}
+
+function resizeHandle(hasCapture = true) {
+  return {
+    setPointerCapture: vi.fn(),
+    hasPointerCapture: vi.fn().mockReturnValue(hasCapture),
+    releasePointerCapture: vi.fn(),
+  };
+}
+
+function pointerEvent(
+  handle: ReturnType<typeof resizeHandle>,
+  pointerId: number,
+  clientX: number,
+  overrides: Partial<PointerEvent> = {},
+): PointerEvent {
+  return {
+    button: 0,
+    clientX,
+    currentTarget: handle,
+    isPrimary: true,
+    pointerId,
+    preventDefault: vi.fn(),
+    ...overrides,
+  } as unknown as PointerEvent;
 }

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.spec.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.spec.ts
@@ -15,6 +15,7 @@ describe('PersistentPanelComponent', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('posts context and lifecycle messages only to the registered origin', () => {
@@ -74,7 +75,7 @@ describe('PersistentPanelComponent', () => {
     component.resize(pointerEvent(handle, 7, 1199));
     expect(component.panelWidth()).toBe(320);
     component.resize(pointerEvent(handle, 7, 0));
-    expect(component.panelWidth()).toBe(1132);
+    expect(component.panelWidth()).toBe(600);
 
     component.finishResize(pointerEvent(handle, 7, 0));
     expect(handle.releasePointerCapture).toHaveBeenCalledWith(7);
@@ -104,7 +105,7 @@ describe('PersistentPanelComponent', () => {
       key: 'End',
       preventDefault,
     } as unknown as KeyboardEvent);
-    expect(component.panelWidth()).toBe(1132);
+    expect(component.panelWidth()).toBe(600);
     expect(preventDefault).toHaveBeenCalledTimes(3);
     component.ngOnDestroy();
   });
@@ -119,16 +120,195 @@ describe('PersistentPanelComponent', () => {
       key: 'End',
       preventDefault: vi.fn(),
     } as unknown as KeyboardEvent);
-    expect(component.panelWidth()).toBe(1132);
+    expect(component.panelWidth()).toBe(600);
 
     viewportWidth = 800;
     window.dispatchEvent(new Event('resize'));
-    expect(component.panelWidth()).toBe(732);
+    expect(component.panelWidth()).toBe(400);
 
     viewportWidth = 1200;
     window.dispatchEvent(new Event('resize'));
-    expect(component.panelWidth()).toBe(1132);
+    expect(component.panelWidth()).toBe(600);
     component.ngOnDestroy();
+  });
+
+  it('limits the panel to half of the measured Portal main area', () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1400);
+    const mainArea = portalLayoutElement('iframeContainer', 280);
+    const component = createPanel();
+
+    expect(component.maxPanelWidth()).toBe(560);
+    component.open(config, {});
+    expect(component.panelWidth()).toBe(544);
+    expect(mainArea.style.right).toBe('544px');
+
+    component.resizeWithKeyboard({
+      key: 'ArrowRight',
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent);
+    expect(component.panelWidth()).toBe(512);
+
+    component.toggleSize();
+    expect(component.state()).toBe('maximized');
+    expect(component.panelWidth()).toBe(560);
+    expect(mainArea.style.right).toBe('560px');
+
+    component.toggleSize();
+    expect(component.state()).toBe('expanded');
+    expect(component.panelWidth()).toBe(512);
+    expect(mainArea.style.right).toBe('512px');
+
+    component.ngOnDestroy();
+    expect(mainArea.style.right).toBe('');
+    mainArea.remove();
+  });
+
+  it('resizes and restores every Portal main-area layer', () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200);
+    const mainArea = portalLayoutElement('iframeContainer', 200);
+    const spinner = portalLayoutElement('spinnerContainer appSpinner', 200);
+    const modalSpinner = portalLayoutElement('spinnerContainer', 200);
+    const tabs = portalLayoutElement('', 200, 'tabsContainer');
+    const splitView = portalLayoutElement('', 200, 'splitViewContainer');
+    const splitDragger = portalLayoutElement('', 200, 'splitViewDragger');
+    const splitBackdrop = portalLayoutElement(
+      '',
+      200,
+      'splitViewDraggerBackdrop',
+    );
+    mainArea.style.setProperty('right', '12px', 'important');
+    const component = createPanel();
+
+    component.open(config, {});
+    expect(component.maxPanelWidth()).toBe(500);
+    expect(component.panelWidth()).toBe(500);
+    expect(mainArea.style.right).toBe('500px');
+    expect(spinner.style.right).toBe('500px');
+    expect(tabs.style.right).toBe('500px');
+    expect(splitView.style.right).toBe('500px');
+    expect(splitDragger.style.right).toBe('500px');
+    expect(splitBackdrop.style.right).toBe('500px');
+    expect(modalSpinner.style.right).toBe('');
+
+    component.resizeWithKeyboard({
+      key: 'ArrowRight',
+      preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent);
+    expect(component.panelWidth()).toBe(468);
+    expect(mainArea.style.right).toBe('468px');
+
+    component.collapse();
+    expect(mainArea.style.getPropertyValue('right')).toBe('12px');
+    expect(mainArea.style.getPropertyPriority('right')).toBe('important');
+    expect(spinner.style.right).toBe('');
+    expect(tabs.style.right).toBe('');
+    expect(splitView.style.right).toBe('');
+    expect(splitDragger.style.right).toBe('');
+    expect(splitBackdrop.style.right).toBe('');
+    expect(modalSpinner.style.right).toBe('');
+
+    component.expand();
+    expect(mainArea.style.right).toBe('468px');
+    component.close();
+    expect(mainArea.style.getPropertyValue('right')).toBe('12px');
+    expect(mainArea.style.getPropertyPriority('right')).toBe('important');
+    component.ngOnDestroy();
+    expect(mainArea.style.getPropertyValue('right')).toBe('12px');
+    expect(mainArea.style.getPropertyPriority('right')).toBe('important');
+
+    mainArea.remove();
+    spinner.remove();
+    tabs.remove();
+    splitView.remove();
+    splitDragger.remove();
+    splitBackdrop.remove();
+    modalSpinner.remove();
+  });
+
+  it('applies the current inset to Portal layers added after opening', async () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200);
+    const mainArea = portalLayoutElement('iframeContainer', 200);
+    const component = createPanel();
+    component.open(config, {});
+
+    const spinner = portalLayoutElement('spinnerContainer appSpinner', 200);
+    await nextMicrotask();
+    expect(spinner.style.right).toBe('500px');
+
+    component.ngOnDestroy();
+    mainArea.remove();
+    spinner.remove();
+  });
+
+  it('recomputes the limit when the Portal navigation resizes the main area', () => {
+    let notifyResize: ResizeObserverCallback = () => undefined;
+    class ResizeObserverMock {
+      constructor(callback: ResizeObserverCallback) {
+        notifyResize = callback;
+      }
+      observe = vi.fn();
+      disconnect = vi.fn();
+    }
+    vi.stubGlobal('ResizeObserver', ResizeObserverMock);
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200);
+    let mainAreaLeft = 200;
+    const mainArea = document.createElement('div');
+    mainArea.className = 'iframeContainer';
+    vi.spyOn(mainArea, 'getBoundingClientRect').mockImplementation(
+      () =>
+        ({
+          left: mainAreaLeft,
+        }) as DOMRect,
+    );
+    document.body.appendChild(mainArea);
+    const component = createPanel();
+    component.open(config, {});
+    expect(component.maxPanelWidth()).toBe(500);
+
+    mainAreaLeft = 400;
+    notifyResize([], {} as ResizeObserver);
+
+    expect(component.maxPanelWidth()).toBe(400);
+    expect(component.panelWidth()).toBe(400);
+    expect(mainArea.style.right).toBe('400px');
+
+    component.ngOnDestroy();
+    mainArea.remove();
+  });
+
+  it('restores the main area when crossing into mobile full-screen mode', () => {
+    let viewportWidth = 1200;
+    vi.spyOn(window, 'innerWidth', 'get').mockImplementation(
+      () => viewportWidth,
+    );
+    const mainArea = portalLayoutElement('iframeContainer', 200);
+    const component = createPanel();
+    component.open(config, {});
+    expect(mainArea.style.right).toBe('500px');
+
+    viewportWidth = 600;
+    window.dispatchEvent(new Event('resize'));
+    expect(mainArea.style.right).toBe('');
+
+    viewportWidth = 1200;
+    window.dispatchEvent(new Event('resize'));
+    expect(mainArea.style.right).toBe('500px');
+
+    component.ngOnDestroy();
+    mainArea.remove();
+  });
+
+  it('keeps the Portal layout unchanged in the mobile full-screen mode', () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(600);
+    const mainArea = portalLayoutElement('iframeContainer', 0);
+    const component = createPanel();
+
+    component.open(config, {});
+    expect(component.maxPanelWidth()).toBe(600);
+    expect(mainArea.style.right).toBe('');
+
+    component.ngOnDestroy();
+    mainArea.remove();
   });
 
   it('derives panel bounds from the Portal root font size', () => {
@@ -139,8 +319,8 @@ describe('PersistentPanelComponent', () => {
     const component = createPanel();
 
     expect(component.minPanelWidth()).toBe(400);
-    expect(component.panelWidth()).toBe(680);
-    expect(component.maxPanelWidth()).toBe(1115);
+    expect(component.panelWidth()).toBe(600);
+    expect(component.maxPanelWidth()).toBe(600);
     component.ngOnDestroy();
   });
 
@@ -154,15 +334,15 @@ describe('PersistentPanelComponent', () => {
     );
     const component = createPanel();
 
-    expect(component.minPanelWidth()).toBe(465);
-    expect(component.panelWidth()).toBe(465);
-    expect(component.maxPanelWidth()).toBe(465);
+    expect(component.minPanelWidth()).toBe(300);
+    expect(component.panelWidth()).toBe(300);
+    expect(component.maxPanelWidth()).toBe(300);
 
     viewportWidth = 1600;
     window.dispatchEvent(new Event('resize'));
     expect(component.minPanelWidth()).toBe(640);
-    expect(component.panelWidth()).toBe(1088);
-    expect(component.maxPanelWidth()).toBe(1464);
+    expect(component.panelWidth()).toBe(800);
+    expect(component.maxPanelWidth()).toBe(800);
     component.ngOnDestroy();
   });
 
@@ -176,11 +356,11 @@ describe('PersistentPanelComponent', () => {
     component.beginResize(pointerEvent(handle, 7, 0, { button: 1 }));
     component.beginResize(pointerEvent(handle, 7, 0, { isPrimary: false }));
     expect(component.resizing()).toBe(false);
-    expect(component.maxPanelWidth()).toBe(132);
+    expect(component.maxPanelWidth()).toBe(200);
 
     component.beginResize(pointerEvent(handle, 7, 0));
     component.resize(pointerEvent(handle, 8, 0));
-    expect(component.panelWidth()).toBe(132);
+    expect(component.panelWidth()).toBe(200);
     component.finishResize(pointerEvent(handle, 8, 0));
     expect(component.resizing()).toBe(true);
     component.finishResize(pointerEvent(handle, 7, 0));
@@ -416,6 +596,14 @@ describe('PersistentPanelComponent', () => {
   });
 
   it('keeps the iframe visible when the provider reports cleanup failure', () => {
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200);
+    let mainAreaLeft = 200;
+    const mainArea = document.createElement('div');
+    mainArea.className = 'iframeContainer';
+    vi.spyOn(mainArea, 'getBoundingClientRect').mockImplementation(
+      () => ({ left: mainAreaLeft }) as DOMRect,
+    );
+    document.body.appendChild(mainArea);
     const frameWindow = { postMessage: vi.fn() } as unknown as WindowProxy;
     const component = createPanel();
     component.panelFrame = new ElementRef({
@@ -430,6 +618,7 @@ describe('PersistentPanelComponent', () => {
       }),
     );
     component.close();
+    mainAreaLeft = 400;
 
     window.dispatchEvent(
       new MessageEvent('message', {
@@ -442,7 +631,10 @@ describe('PersistentPanelComponent', () => {
     expect(component.closing()).toBe(false);
     expect(component.source()).not.toBeNull();
     expect(component.state()).toBe('expanded');
+    expect(component.maxPanelWidth()).toBe(400);
+    expect(mainArea.style.right).toBe('400px');
     component.ngOnDestroy();
+    mainArea.remove();
   });
 });
 
@@ -491,4 +683,27 @@ function pointerEvent(
     preventDefault: vi.fn(),
     ...overrides,
   } as unknown as PointerEvent;
+}
+
+function portalLayoutElement(
+  className: string,
+  left: number,
+  id = '',
+): HTMLElement {
+  const element = document.createElement('div');
+  element.className = className;
+  element.id = id;
+  vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+    bottom: 800,
+    height: 800,
+    left,
+    right: window.innerWidth,
+    top: 0,
+    width: window.innerWidth - left,
+    x: left,
+    y: 0,
+    toJSON: () => ({}),
+  });
+  document.body.appendChild(element);
+  return element;
 }

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.spec.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.spec.ts
@@ -138,9 +138,31 @@ describe('PersistentPanelComponent', () => {
     vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1200);
     const component = createPanel();
 
-    expect(component.minPanelWidth).toBe(400);
+    expect(component.minPanelWidth()).toBe(400);
     expect(component.panelWidth()).toBe(680);
     expect(component.maxPanelWidth()).toBe(1115);
+    component.ngOnDestroy();
+  });
+
+  it('keeps the panel and ARIA bounds inside a narrow large-text viewport', () => {
+    vi.spyOn(window, 'getComputedStyle').mockReturnValue({
+      fontSize: '32px',
+    } as CSSStyleDeclaration);
+    let viewportWidth = 601;
+    vi.spyOn(window, 'innerWidth', 'get').mockImplementation(
+      () => viewportWidth,
+    );
+    const component = createPanel();
+
+    expect(component.minPanelWidth()).toBe(465);
+    expect(component.panelWidth()).toBe(465);
+    expect(component.maxPanelWidth()).toBe(465);
+
+    viewportWidth = 1600;
+    window.dispatchEvent(new Event('resize'));
+    expect(component.minPanelWidth()).toBe(640);
+    expect(component.panelWidth()).toBe(1088);
+    expect(component.maxPanelWidth()).toBe(1464);
     component.ngOnDestroy();
   });
 
@@ -154,11 +176,11 @@ describe('PersistentPanelComponent', () => {
     component.beginResize(pointerEvent(handle, 7, 0, { button: 1 }));
     component.beginResize(pointerEvent(handle, 7, 0, { isPrimary: false }));
     expect(component.resizing()).toBe(false);
-    expect(component.maxPanelWidth()).toBe(320);
+    expect(component.maxPanelWidth()).toBe(132);
 
     component.beginResize(pointerEvent(handle, 7, 0));
     component.resize(pointerEvent(handle, 8, 0));
-    expect(component.panelWidth()).toBe(320);
+    expect(component.panelWidth()).toBe(132);
     component.finishResize(pointerEvent(handle, 8, 0));
     expect(component.resizing()).toBe(true);
     component.finishResize(pointerEvent(handle, 7, 0));

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.ts
@@ -18,11 +18,6 @@ import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 type PanelState = 'hidden' | 'expanded' | 'maximized';
 
-const DEFAULT_PANEL_WIDTH = 34 * 16;
-const MIN_PANEL_WIDTH = 20 * 16;
-const PORTAL_NAVIGATION_WIDTH = 4.25 * 16;
-const KEYBOARD_RESIZE_STEP = 2 * 16;
-
 @Component({
   selector: 'pm-persistent-panel',
   imports: [CommonModule],
@@ -35,7 +30,8 @@ export class PersistentPanelComponent implements OnDestroy {
   @ViewChild('panelFrame') panelFrame?: ElementRef<HTMLIFrameElement>;
   @ViewChild('reopenButton') reopenButton?: ElementRef<HTMLButtonElement>;
 
-  private readonly preferredPanelWidth = signal(DEFAULT_PANEL_WIDTH);
+  private readonly dimensions = panelDimensions();
+  private readonly preferredPanelWidth = signal(this.dimensions.defaultWidth);
 
   readonly state = signal<PanelState>('hidden');
   readonly title = signal('');
@@ -43,7 +39,7 @@ export class PersistentPanelComponent implements OnDestroy {
   readonly closing = signal(false);
   readonly closeError = signal('');
   readonly resizing = signal(false);
-  readonly minPanelWidth = MIN_PANEL_WIDTH;
+  readonly minPanelWidth = this.dimensions.minimumWidth;
   readonly maxPanelWidth = signal(this.availablePanelWidth());
   readonly panelWidth = computed(() =>
     Math.min(this.preferredPanelWidth(), this.maxPanelWidth()),
@@ -181,13 +177,13 @@ export class PersistentPanelComponent implements OnDestroy {
     let width: number;
     switch (event.key) {
       case 'ArrowLeft':
-        width = this.panelWidth() + KEYBOARD_RESIZE_STEP;
+        width = this.panelWidth() + this.dimensions.keyboardStep;
         break;
       case 'ArrowRight':
-        width = this.panelWidth() - KEYBOARD_RESIZE_STEP;
+        width = this.panelWidth() - this.dimensions.keyboardStep;
         break;
       case 'Home':
-        width = MIN_PANEL_WIDTH;
+        width = this.minPanelWidth;
         break;
       case 'End':
         width = this.maxPanelWidth();
@@ -313,14 +309,14 @@ export class PersistentPanelComponent implements OnDestroy {
 
   private setPanelWidth(width: number): void {
     this.preferredPanelWidth.set(
-      Math.min(Math.max(width, MIN_PANEL_WIDTH), this.maxPanelWidth()),
+      Math.min(Math.max(width, this.minPanelWidth), this.maxPanelWidth()),
     );
   }
 
   private availablePanelWidth(): number {
     return Math.max(
-      MIN_PANEL_WIDTH,
-      window.innerWidth - PORTAL_NAVIGATION_WIDTH,
+      this.minPanelWidth,
+      window.innerWidth - this.dimensions.navigationWidth,
     );
   }
 
@@ -367,4 +363,18 @@ export class PersistentPanelComponent implements OnDestroy {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function panelDimensions() {
+  const rootFontSize = Number.parseFloat(
+    window.getComputedStyle(document.documentElement).fontSize,
+  );
+  const rem =
+    Number.isFinite(rootFontSize) && rootFontSize > 0 ? rootFontSize : 16;
+  return {
+    defaultWidth: 34 * rem,
+    minimumWidth: 20 * rem,
+    navigationWidth: 4.25 * rem,
+    keyboardStep: 2 * rem,
+  };
 }

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.ts
@@ -10,12 +10,18 @@ import {
   ElementRef,
   OnDestroy,
   ViewChild,
+  computed,
   inject,
   signal,
 } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 type PanelState = 'hidden' | 'expanded' | 'maximized';
+
+const DEFAULT_PANEL_WIDTH = 34 * 16;
+const MIN_PANEL_WIDTH = 20 * 16;
+const PORTAL_NAVIGATION_WIDTH = 4.25 * 16;
+const KEYBOARD_RESIZE_STEP = 2 * 16;
 
 @Component({
   selector: 'pm-persistent-panel',
@@ -29,11 +35,19 @@ export class PersistentPanelComponent implements OnDestroy {
   @ViewChild('panelFrame') panelFrame?: ElementRef<HTMLIFrameElement>;
   @ViewChild('reopenButton') reopenButton?: ElementRef<HTMLButtonElement>;
 
+  private readonly preferredPanelWidth = signal(DEFAULT_PANEL_WIDTH);
+
   readonly state = signal<PanelState>('hidden');
   readonly title = signal('');
   readonly source = signal<SafeResourceUrl | null>(null);
   readonly closing = signal(false);
   readonly closeError = signal('');
+  readonly resizing = signal(false);
+  readonly minPanelWidth = MIN_PANEL_WIDTH;
+  readonly maxPanelWidth = signal(this.availablePanelWidth());
+  readonly panelWidth = computed(() =>
+    Math.min(this.preferredPanelWidth(), this.maxPanelWidth()),
+  );
 
   private readonly sanitizer = inject(DomSanitizer);
   private config: PersistentPanelConfig | null = null;
@@ -45,15 +59,20 @@ export class PersistentPanelComponent implements OnDestroy {
   private destroyed = false;
   private ready = false;
   private returnFocusElement: HTMLElement | null = null;
+  private resizePointerId: number | null = null;
 
   constructor() {
     window.addEventListener('message', this.onMessage);
+    window.addEventListener('resize', this.onWindowResize);
   }
 
   ngOnDestroy(): void {
     this.destroyed = true;
     window.removeEventListener('message', this.onMessage);
+    window.removeEventListener('resize', this.onWindowResize);
     this.clearCloseTimeout();
+    this.resizePointerId = null;
+    this.resizing.set(false);
   }
 
   open(config: PersistentPanelConfig, target: PersistentPanelTarget): void {
@@ -121,6 +140,63 @@ export class PersistentPanelComponent implements OnDestroy {
     this.state.update((state) =>
       state === 'maximized' ? 'expanded' : 'maximized',
     );
+  }
+
+  beginResize(event: PointerEvent): void {
+    if (
+      this.state() !== 'expanded' ||
+      event.button !== 0 ||
+      event.isPrimary === false
+    ) {
+      return;
+    }
+    this.resizePointerId = event.pointerId;
+    this.resizing.set(true);
+    (event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+    event.preventDefault();
+  }
+
+  resize(event: PointerEvent): void {
+    if (event.pointerId !== this.resizePointerId) {
+      return;
+    }
+    this.setPanelWidth(window.innerWidth - event.clientX);
+    event.preventDefault();
+  }
+
+  finishResize(event: PointerEvent): void {
+    if (event.pointerId !== this.resizePointerId) {
+      return;
+    }
+    const handle = event.currentTarget as HTMLElement;
+    if (handle.hasPointerCapture(event.pointerId)) {
+      handle.releasePointerCapture(event.pointerId);
+    }
+    this.resizePointerId = null;
+    this.resizing.set(false);
+    event.preventDefault();
+  }
+
+  resizeWithKeyboard(event: KeyboardEvent): void {
+    let width: number;
+    switch (event.key) {
+      case 'ArrowLeft':
+        width = this.panelWidth() + KEYBOARD_RESIZE_STEP;
+        break;
+      case 'ArrowRight':
+        width = this.panelWidth() - KEYBOARD_RESIZE_STEP;
+        break;
+      case 'Home':
+        width = MIN_PANEL_WIDTH;
+        break;
+      case 'End':
+        width = this.maxPanelWidth();
+        break;
+      default:
+        return;
+    }
+    this.setPanelWidth(width);
+    event.preventDefault();
   }
 
   close(): void {
@@ -234,6 +310,23 @@ export class PersistentPanelComponent implements OnDestroy {
       this.config.origin,
     );
   }
+
+  private setPanelWidth(width: number): void {
+    this.preferredPanelWidth.set(
+      Math.min(Math.max(width, MIN_PANEL_WIDTH), this.maxPanelWidth()),
+    );
+  }
+
+  private availablePanelWidth(): number {
+    return Math.max(
+      MIN_PANEL_WIDTH,
+      window.innerWidth - PORTAL_NAVIGATION_WIDTH,
+    );
+  }
+
+  private readonly onWindowResize = (): void => {
+    this.maxPanelWidth.set(this.availablePanelWidth());
+  };
 
   private readonly onMessage = (event: MessageEvent<unknown>): void => {
     const frame = this.panelFrame?.nativeElement;

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.ts
@@ -39,10 +39,15 @@ export class PersistentPanelComponent implements OnDestroy {
   readonly closing = signal(false);
   readonly closeError = signal('');
   readonly resizing = signal(false);
-  readonly minPanelWidth = this.dimensions.minimumWidth;
   readonly maxPanelWidth = signal(this.availablePanelWidth());
+  readonly minPanelWidth = computed(() =>
+    Math.min(this.dimensions.minimumWidth, this.maxPanelWidth()),
+  );
   readonly panelWidth = computed(() =>
-    Math.min(this.preferredPanelWidth(), this.maxPanelWidth()),
+    Math.max(
+      this.minPanelWidth(),
+      Math.min(this.preferredPanelWidth(), this.maxPanelWidth()),
+    ),
   );
 
   private readonly sanitizer = inject(DomSanitizer);
@@ -183,7 +188,7 @@ export class PersistentPanelComponent implements OnDestroy {
         width = this.panelWidth() - this.dimensions.keyboardStep;
         break;
       case 'Home':
-        width = this.minPanelWidth;
+        width = this.minPanelWidth();
         break;
       case 'End':
         width = this.maxPanelWidth();
@@ -309,15 +314,12 @@ export class PersistentPanelComponent implements OnDestroy {
 
   private setPanelWidth(width: number): void {
     this.preferredPanelWidth.set(
-      Math.min(Math.max(width, this.minPanelWidth), this.maxPanelWidth()),
+      Math.min(Math.max(width, this.minPanelWidth()), this.maxPanelWidth()),
     );
   }
 
   private availablePanelWidth(): number {
-    return Math.max(
-      this.minPanelWidth,
-      window.innerWidth - this.dimensions.navigationWidth,
-    );
+    return Math.max(1, window.innerWidth - this.dimensions.navigationWidth);
   }
 
   private readonly onWindowResize = (): void => {

--- a/projects/lib/portal-options/persistent-panel/persistent-panel.ts
+++ b/projects/lib/portal-options/persistent-panel/persistent-panel.ts
@@ -18,6 +18,21 @@ import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 type PanelState = 'hidden' | 'expanded' | 'maximized';
 
+const PORTAL_MAIN_AREA_SELECTOR = '.iframeContainer';
+const PORTAL_LAYOUT_SELECTORS = [
+  PORTAL_MAIN_AREA_SELECTOR,
+  '.spinnerContainer.appSpinner',
+  '#splitViewContainer',
+  '#splitViewDragger',
+  '#splitViewDraggerBackdrop',
+  '#tabsContainer',
+].join(',');
+
+interface InlineStyleValue {
+  value: string;
+  priority: string;
+}
+
 @Component({
   selector: 'pm-persistent-panel',
   imports: [CommonModule],
@@ -46,7 +61,12 @@ export class PersistentPanelComponent implements OnDestroy {
   readonly panelWidth = computed(() =>
     Math.max(
       this.minPanelWidth(),
-      Math.min(this.preferredPanelWidth(), this.maxPanelWidth()),
+      Math.min(
+        this.state() === 'maximized'
+          ? this.maxPanelWidth()
+          : this.preferredPanelWidth(),
+        this.maxPanelWidth(),
+      ),
     ),
   );
 
@@ -61,6 +81,29 @@ export class PersistentPanelComponent implements OnDestroy {
   private ready = false;
   private returnFocusElement: HTMLElement | null = null;
   private resizePointerId: number | null = null;
+  private observingPortalLayout = false;
+  private observedMainArea: HTMLElement | null = null;
+  private readonly portalLayoutStyles = new Map<
+    HTMLElement,
+    InlineStyleValue
+  >();
+  private readonly portalLayoutObserver = new MutationObserver(() => {
+    if (this.state() === 'hidden') {
+      return;
+    }
+    this.maxPanelWidth.set(this.availablePanelWidth());
+    this.syncPortalLayout();
+  });
+  private readonly mainAreaResizeObserver =
+    typeof ResizeObserver === 'undefined'
+      ? null
+      : new ResizeObserver(() => {
+          if (this.state() === 'hidden') {
+            return;
+          }
+          this.maxPanelWidth.set(this.availablePanelWidth());
+          this.syncPortalLayout();
+        });
 
   constructor() {
     window.addEventListener('message', this.onMessage);
@@ -74,6 +117,9 @@ export class PersistentPanelComponent implements OnDestroy {
     this.clearCloseTimeout();
     this.resizePointerId = null;
     this.resizing.set(false);
+    this.portalLayoutObserver.disconnect();
+    this.mainAreaResizeObserver?.disconnect();
+    this.restorePortalLayout();
   }
 
   open(config: PersistentPanelConfig, target: PersistentPanelTarget): void {
@@ -102,7 +148,9 @@ export class PersistentPanelComponent implements OnDestroy {
         this.sanitizer.bypassSecurityTrustResourceUrl(config.url),
       );
     }
+    this.maxPanelWidth.set(this.availablePanelWidth());
     this.state.set('expanded');
+    this.syncPortalLayout();
     queueMicrotask(() => {
       if (this.destroyed) {
         return;
@@ -114,11 +162,14 @@ export class PersistentPanelComponent implements OnDestroy {
 
   updateTarget(target: PersistentPanelTarget): void {
     this.target = structuredClone(target);
+    this.maxPanelWidth.set(this.availablePanelWidth());
+    this.syncPortalLayout();
     this.publishTarget();
   }
 
   collapse(): void {
     this.state.set('hidden');
+    this.syncPortalLayout();
     queueMicrotask(() => {
       if (this.destroyed) {
         return;
@@ -128,7 +179,9 @@ export class PersistentPanelComponent implements OnDestroy {
   }
 
   expand(): void {
+    this.maxPanelWidth.set(this.availablePanelWidth());
     this.state.set('expanded');
+    this.syncPortalLayout();
     queueMicrotask(() => {
       if (this.destroyed) {
         return;
@@ -141,6 +194,7 @@ export class PersistentPanelComponent implements OnDestroy {
     this.state.update((state) =>
       state === 'maximized' ? 'expanded' : 'maximized',
     );
+    this.syncPortalLayout();
   }
 
   beginResize(event: PointerEvent): void {
@@ -210,6 +264,7 @@ export class PersistentPanelComponent implements OnDestroy {
     this.closing.set(true);
     this.closeError.set('');
     this.state.set('hidden');
+    this.syncPortalLayout();
     this.focusReturnTarget();
     this.requestCloseIfReady(requestId);
     this.closeTimeout = window.setTimeout(() => {
@@ -225,7 +280,9 @@ export class PersistentPanelComponent implements OnDestroy {
     this.closeRequestIdSent = null;
     this.closing.set(false);
     this.closeError.set('Provider cleanup is incomplete. Try closing again.');
+    this.maxPanelWidth.set(this.availablePanelWidth());
     this.state.set('expanded');
+    this.syncPortalLayout();
     queueMicrotask(() => {
       if (this.destroyed) {
         return;
@@ -251,6 +308,7 @@ export class PersistentPanelComponent implements OnDestroy {
     this.source.set(null);
     this.title.set('');
     this.state.set('hidden');
+    this.syncPortalLayout();
     this.focusReturnTarget();
     this.returnFocusElement = null;
   }
@@ -263,6 +321,8 @@ export class PersistentPanelComponent implements OnDestroy {
   }
 
   frameLoaded(): void {
+    this.maxPanelWidth.set(this.availablePanelWidth());
+    this.syncPortalLayout();
     this.publishTarget();
   }
 
@@ -316,14 +376,102 @@ export class PersistentPanelComponent implements OnDestroy {
     this.preferredPanelWidth.set(
       Math.min(Math.max(width, this.minPanelWidth()), this.maxPanelWidth()),
     );
+    this.syncPortalLayout();
   }
 
   private availablePanelWidth(): number {
-    return Math.max(1, window.innerWidth - this.dimensions.navigationWidth);
+    if (this.isMobileViewport()) {
+      return Math.max(1, window.innerWidth);
+    }
+    return Math.max(1, Math.floor(this.availableMainAreaWidth() / 2));
+  }
+
+  private availableMainAreaWidth(): number {
+    const mainArea = document.querySelector<HTMLElement>(
+      PORTAL_MAIN_AREA_SELECTOR,
+    );
+    if (mainArea) {
+      return Math.max(
+        1,
+        window.innerWidth - mainArea.getBoundingClientRect().left,
+      );
+    }
+    return Math.max(1, window.innerWidth);
+  }
+
+  private syncPortalLayout(): void {
+    if (this.state() === 'hidden' || this.isMobileViewport()) {
+      this.stopObservingPortalLayout();
+      this.restorePortalLayout();
+      return;
+    }
+
+    this.observePortalLayout();
+    const offset = `${this.panelWidth()}px`;
+    document
+      .querySelectorAll<HTMLElement>(PORTAL_LAYOUT_SELECTORS)
+      .forEach((element) => {
+        if (!this.portalLayoutStyles.has(element)) {
+          this.portalLayoutStyles.set(element, {
+            value: element.style.getPropertyValue('right'),
+            priority: element.style.getPropertyPriority('right'),
+          });
+        }
+        element.style.setProperty('right', offset);
+      });
+  }
+
+  private restorePortalLayout(): void {
+    this.portalLayoutStyles.forEach(({ value, priority }, element) => {
+      if (value) {
+        element.style.setProperty('right', value, priority);
+      } else {
+        element.style.removeProperty('right');
+      }
+    });
+    this.portalLayoutStyles.clear();
+  }
+
+  private observePortalLayout(): void {
+    this.observeMainAreaResize();
+    if (this.observingPortalLayout) {
+      return;
+    }
+    this.portalLayoutObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+    this.observingPortalLayout = true;
+  }
+
+  private stopObservingPortalLayout(): void {
+    this.portalLayoutObserver.disconnect();
+    this.mainAreaResizeObserver?.disconnect();
+    this.observedMainArea = null;
+    this.observingPortalLayout = false;
+  }
+
+  private observeMainAreaResize(): void {
+    const mainArea = document.querySelector<HTMLElement>(
+      PORTAL_MAIN_AREA_SELECTOR,
+    );
+    if (!this.mainAreaResizeObserver || mainArea === this.observedMainArea) {
+      return;
+    }
+    this.mainAreaResizeObserver.disconnect();
+    this.observedMainArea = mainArea;
+    if (mainArea) {
+      this.mainAreaResizeObserver.observe(mainArea);
+    }
+  }
+
+  private isMobileViewport(): boolean {
+    return window.innerWidth <= 600;
   }
 
   private readonly onWindowResize = (): void => {
     this.maxPanelWidth.set(this.availablePanelWidth());
+    this.syncPortalLayout();
   };
 
   private readonly onMessage = (event: MessageEvent<unknown>): void => {
@@ -376,7 +524,6 @@ function panelDimensions() {
   return {
     defaultWidth: 34 * rem,
     minimumWidth: 20 * rem,
-    navigationWidth: 4.25 * rem,
     keyboardStep: 2 * rem,
   };
 }


### PR DESCRIPTION
## Summary

- add pointer and keyboard resizing to persistent provider panels
- keep the panel within navigation-aware viewport bounds while preserving its preferred width
- prevent the panel shadow from overlapping the shellbar corner
- retain the existing mobile full-width and maximize behavior

## Verification

- `npm run test` (958 tests)
- `npm run build`

## Related

Refs platform-mesh/backlog#344